### PR TITLE
Updated headers to H1 on content pages

### DIFF
--- a/content/AMR_Clinical_Metadata
+++ b/content/AMR_Clinical_Metadata
@@ -1,5 +1,5 @@
 <div class="dlp">
-    <h2>Antimicrobial Resistance and Other Clinical Metadata</h2>
+    <h1>Antimicrobial Resistance and Other Clinical Metadata</h1>
     <section class="main">
         <div class="data-box">
             <h3 class="ribbon-title">Genome-Level Antimicrobial Resistance (AMR)</h3>

--- a/content/BLAST
+++ b/content/BLAST
@@ -1,5 +1,5 @@
 <div class="dlp">
-    <h2>BLAST Service</h2>
+    <h1>BLAST Service</h1>
 
     <section class="main">
         <div class="data-box">

--- a/content/Circular_Genome_Viewer
+++ b/content/Circular_Genome_Viewer
@@ -1,5 +1,5 @@
 <div class="dlp">
-    <h2>Circular Genome Viewer</h2>
+    <h1>Circular Genome Viewer</h1>
 
     <section class="main">
         <div class="data-box">

--- a/content/CitePATRIC
+++ b/content/CitePATRIC
@@ -1,5 +1,5 @@
 <div class="dlp">
-    <h2>Citing PATRIC</h2>
+    <h1>Citing PATRIC</h1>
     <section class="main">
         <p>If you use PATRIC web resources to assist in research publications or proposals please cite as:</p>
         <div class="data-box">

--- a/content/Comparative_Pathway
+++ b/content/Comparative_Pathway
@@ -1,5 +1,5 @@
 <div class="dlp">
-    <h2>Comparative Pathway Tool</h2>
+    <h1>Comparative Pathway Tool</h1>
 
     <section class="main">
         <div class="data-box">

--- a/content/Comparative_Pathway_Heatmap
+++ b/content/Comparative_Pathway_Heatmap
@@ -1,5 +1,5 @@
 <div class="dlp">
-    <h2>Comparative Pathway Heatmap</h2>
+    <h1>Comparative Pathway Heatmap</h1>
 
     <section class="main">
         <div class="data-box">

--- a/content/Comparative_Pathway_KEGG_Map
+++ b/content/Comparative_Pathway_KEGG_Map
@@ -1,5 +1,5 @@
 <div class="dlp">
-    <h2>Comparative Pathway KEGG Map</h2>
+    <h1>Comparative Pathway KEGG Map</h1>
 
     <section class="main">
         <div class="data-box">

--- a/content/ContactUs
+++ b/content/ContactUs
@@ -1,9 +1,9 @@
 <div style="width:80%;margin:auto">
-<h2 class="entry-title">
+<h1 class="entry-title">
 		<a href="http://enews.patricbrc.org/contact-us/"
 			title="Permalink to Contact Us"
 			rel="bookmark">Contact Us </a>
-				</h2>
+				</h1>
 	
 		
 			<div class="entry-summary">

--- a/content/Curated_Virulence_Factors
+++ b/content/Curated_Virulence_Factors
@@ -1,5 +1,5 @@
 <div class="dlp">
-    <h2>Curated Virulence Factors</h2>
+    <h1>Curated Virulence Factors</h1>
 
     <section class="main">
         <div class="data-box">

--- a/content/Data_Submission
+++ b/content/Data_Submission
@@ -1,5 +1,5 @@
 <div class="dlp">
-    <h2>Data Submission to PATRIC</h2>
+    <h1>Data Submission to PATRIC</h1>
 
     <section class="main">
         <div class="data-box">

--- a/content/Differential_Expression
+++ b/content/Differential_Expression
@@ -1,5 +1,5 @@
 <div class="dlp">
-    <h2>Differential Expression Data and Tools</h2>
+    <h1>Differential Expression Data and Tools</h1>
 
     <section class="main">
         <div class="data-box">

--- a/content/Download_Data
+++ b/content/Download_Data
@@ -1,5 +1,5 @@
 <div class="dlp">
-    <h2>Download Data</h2>
+    <h1>Download Data</h1>
 
     <section class="main">
         <div class="data-box">

--- a/content/Feature_Table
+++ b/content/Feature_Table
@@ -1,5 +1,5 @@
 <div class="dlp">
-    <h2>Feature Table</h2>
+    <h1>Feature Table</h1>
 
     <section class="main">
         <div class="data-box">

--- a/content/Gene_Page_Transcriptomics
+++ b/content/Gene_Page_Transcriptomics
@@ -1,5 +1,5 @@
 <div class="dlp">
-    <h2>Gene Page Transcriptomics Data</h2>
+    <h1>Gene Page Transcriptomics Data</h1>
 
     <section class="main">
         <div class="data-box">

--- a/content/Genome_Annotations
+++ b/content/Genome_Annotations
@@ -1,5 +1,5 @@
 <div class="dlp">
-    <h2>Genome Annotations</h2>
+    <h1>Genome Annotations</h1>
 
     <section class="main">
         <div class="data-box">

--- a/content/Genome_Browser
+++ b/content/Genome_Browser
@@ -1,5 +1,5 @@
 <div class="dlp">
-    <h2>Genome Browser</h2>
+    <h1>Genome Browser</h1>
 
     <section class="main">
         <div class="data-box">

--- a/content/Genome_Data_and_Tools
+++ b/content/Genome_Data_and_Tools
@@ -1,5 +1,5 @@
 <div class="dlp">
-    <h2>Genome Data and Tools</h2>
+    <h1>Genome Data and Tools</h1>
 
     <section class="main">
         <div class="data-box">

--- a/content/Genome_Features_and_Tools
+++ b/content/Genome_Features_and_Tools
@@ -1,5 +1,5 @@
 <div class="dlp">
-    <h2>Genome Feature Data and Tools</h2>
+    <h1>Genome Feature Data and Tools</h1>
 
     <section class="main">
         <div class="data-box">

--- a/content/Genome_Metadata
+++ b/content/Genome_Metadata
@@ -1,5 +1,5 @@
 <div class="dlp">
-    <h2>Genome Metadata</h2>
+    <h1>Genome Metadata</h1>
 
     <section class="main">
         <div class="data-box">

--- a/content/Genomic_Feature_Types
+++ b/content/Genomic_Feature_Types
@@ -1,5 +1,5 @@
 <div class="dlp">
-    <h2>Genomic Feature Types</h2>
+    <h1>Genomic Feature Types</h1>
 
     <section class="main">
         <div class="data-box">

--- a/content/Global_Search
+++ b/content/Global_Search
@@ -1,5 +1,5 @@
 <div class="dlp">
-    <h2>Global Search</h2>
+    <h1>Global Search</h1>
     <section class="main">
         <div class="data-box">
             <h3 class="ribbon-title">Global Search</h3>

--- a/content/ID_Mapping_Tool
+++ b/content/ID_Mapping_Tool
@@ -1,5 +1,5 @@
 <div class="dlp">
-    <h2>ID Mapping Tool</h2>
+    <h1>ID Mapping Tool</h1>
 
     <section class="main">
         <div class="data-box">

--- a/content/Literature
+++ b/content/Literature
@@ -1,5 +1,5 @@
 <div class="dlp">
-    <h2>Literature</h2>
+    <h1>Literature</h1>
 
     <section class="main">
         <div class="data-box">

--- a/content/Multiple_Sequence_Alignment
+++ b/content/Multiple_Sequence_Alignment
@@ -1,5 +1,5 @@
 <div class="dlp">
-    <h2>Multiple Sequence Alignment</h2>
+    <h1>Multiple Sequence Alignment</h1>
 
     <section class="main">
         <div class="data-box">

--- a/content/Other_Data_and_Tools
+++ b/content/Other_Data_and_Tools
@@ -1,5 +1,5 @@
 <div class="dlp">
-    <h2>Other Data and Tools</h2>
+    <h1>Other Data and Tools</h1>
 
     <section class="main">
         <div class="data-box">

--- a/content/Phylogenetic_Trees
+++ b/content/Phylogenetic_Trees
@@ -1,5 +1,5 @@
 <div class="dlp">
-    <h2>Phylogenetic Trees</h2>
+    <h1>Phylogenetic Trees</h1>
 
     <section class="main">
         <div class="data-box">

--- a/content/Protein_Families
+++ b/content/Protein_Families
@@ -1,5 +1,5 @@
 <div class="dlp">
-    <h2>Protein Families</h2>
+    <h1>Protein Families</h1>
 
     <section class="main">
         <div class="data-box">

--- a/content/Protein_Family_Heatmap
+++ b/content/Protein_Family_Heatmap
@@ -1,5 +1,5 @@
 <div class="dlp">
-    <h2>Protein Family Heatmap</h2>
+    <h1>Protein Family Heatmap</h1>
 
     <section class="main">
         <div class="data-box">

--- a/content/Protein_Family_Sorter
+++ b/content/Protein_Family_Sorter
@@ -1,5 +1,5 @@
 <div class="dlp">
-    <h2>Protein Family Sorter</h2>
+    <h1>Protein Family Sorter</h1>
 
     <section class="main">
         <div class="data-box">

--- a/content/Registration
+++ b/content/Registration
@@ -1,5 +1,5 @@
 <div class="dlp">
-    <h2>Registration</h2>
+    <h1>Registration</h1>
 
     <section class="main">
         <div class="data-box">

--- a/content/SWG
+++ b/content/SWG
@@ -1,5 +1,5 @@
 <div class="dlp">
-    <h2>Scientific Working Group</h2>
+    <h1>Scientific Working Group</h1>
     <section class="main">
 
         <p>As part of PATRIC, we have established a Scientific Working Group (SWG) comprised of members with deep

--- a/content/S_enterica_CYT
+++ b/content/S_enterica_CYT
@@ -1,5 +1,5 @@
 <div class='dlp'>
-    <h2>Salmonella enterica Cytoplasmic Identified Proteins</h2>
+    <h1>Salmonella enterica Cytoplasmic Identified Proteins</h1>
 
     <section class='main'>
         <table class="p3basic striped far2x">

--- a/content/S_enterica_IM
+++ b/content/S_enterica_IM
@@ -1,7 +1,7 @@
 <div class='dlp'>
-    <h2>
+    <h1>
         Salmonella enterica Inner Membrane Identified Proteins
-    </h2>
+    </h1>
 
     <section class='main'>
 

--- a/content/S_enterica_OM
+++ b/content/S_enterica_OM
@@ -1,7 +1,7 @@
 <div class='dlp'>
-    <h2>
+    <h1>
         Salmonella enterica Outer Membrane Identified Proteins
-    </h2>
+    </h1>
 
     <section class='main'>
 

--- a/content/S_enterica_PERI
+++ b/content/S_enterica_PERI
@@ -1,7 +1,7 @@
 <div class='dlp'>
-    <h2>
+    <h1>
         Salmonella enterica Periplasmic Identified Proteins
-    </h2>
+    </h1>
 
     <section class='main' role='main'>
 

--- a/content/S_enterica_SPI-2_TTSS
+++ b/content/S_enterica_SPI-2_TTSS
@@ -1,7 +1,7 @@
 <div class='dlp'>
-    <h2>
+    <h1>
         Salmonella enterica Protein Co-regulated with SPI-2 TTSS
-    </h2>
+    </h1>
 
     <section class='main'>
         <table class="p3basic striped far2x">

--- a/content/S_enterica_SPI-2_effector
+++ b/content/S_enterica_SPI-2_effector
@@ -1,7 +1,7 @@
 <div class='dlp'>
-    <h2>
+    <h1>
         Salmonella enterica Known SPI-2 effectors identified
-    </h2>
+    </h1>
 
     <section class='main' role='main'>
 

--- a/content/S_enterica_effector
+++ b/content/S_enterica_effector
@@ -1,7 +1,7 @@
 <div class='dlp'>
-    <h2>
+    <h1>
         Salmonella enterica Novel Secreted Effectors Identified
-    </h2>
+    </h1>
 
     <section class='main'>
 

--- a/content/S_enterica_moonlighting
+++ b/content/S_enterica_moonlighting
@@ -1,7 +1,7 @@
 <div class='dlp'>
-    <h2>
+    <h1>
         Salmonella enterica Moonlighting Identified Proteins
-    </h2>
+    </h1>
 
     <section class='main'>
 

--- a/content/S_enterica_pathogenesis
+++ b/content/S_enterica_pathogenesis
@@ -1,5 +1,5 @@
 <div class='dlp'>
-    <h2>Salmonella enterica Pathogenesis Related Proteins</h2>
+    <h1>Salmonella enterica Pathogenesis Related Proteins</h1>
 
     <section class='main'>
         <table class="p3basic striped far2x">

--- a/content/Specialty_Genes
+++ b/content/Specialty_Genes
@@ -1,5 +1,5 @@
 <div class="dlp">
-    <h2>Specialty Genes</h2>
+    <h1>Specialty Genes</h1>
 
     <section class="main">
         <div class="data-box">

--- a/content/System_Requirements
+++ b/content/System_Requirements
@@ -1,5 +1,5 @@
 <div class="dlp">
-    <h2>Recommended System Requirements</h2>
+    <h1>Recommended System Requirements</h1>
 
     <section class="main">
         <div class="data-box">

--- a/content/Transcriptomics_Experiments_and_Comparisons
+++ b/content/Transcriptomics_Experiments_and_Comparisons
@@ -1,5 +1,5 @@
 <div class="dlp">
-    <h2>Transcriptomics Experiments and Comparisons List</h2>
+    <h1>Transcriptomics Experiments and Comparisons List</h1>
 
     <section class="main">
         <div class="data-box">

--- a/content/Transcriptomics_Gene_List
+++ b/content/Transcriptomics_Gene_List
@@ -1,6 +1,5 @@
 <div class="dlp">
-    <h2>
-        <h2>Transcriptomics Gene List</h2>
+        <h1>Transcriptomics Gene List</h1>
 
         <section class="main">
             <div class="data-box">

--- a/content/Tutorials
+++ b/content/Tutorials
@@ -1,5 +1,5 @@
 <div class="dlp">
-    <h2>Tutorials</h2>
+    <h1>Tutorials</h1>
 
     <section class="main">
         <div class="far2x">

--- a/content/UserGuide
+++ b/content/UserGuide
@@ -1,5 +1,5 @@
 <div class="dlp">
-    <h2>PATRIC Website User Guide</h2>
+    <h1>PATRIC Website User Guide</h1>
     <section class="main">
         <div class="data-box">
             <p>The links below provide overviews of the primary PATRIC website data and tools. To suggest new sections

--- a/content/Website_Overview
+++ b/content/Website_Overview
@@ -1,5 +1,5 @@
 <div class="dlp">
-    <h2>Website Overview</h2>
+    <h1>Website Overview</h1>
 
     <section class="main">
         <div class="data-box">

--- a/content/Workspace_and_Groups
+++ b/content/Workspace_and_Groups
@@ -1,5 +1,5 @@
 <div class="dlp">
-    <h2>Workspace and Groups</h2>
+    <h1>Workspace and Groups</h1>
 
     <section class="main">
         <div class="data-box">

--- a/content/about
+++ b/content/about
@@ -1,5 +1,5 @@
 <div class="dlp">
-    <h2>What is PATRIC?</h2>
+    <h1>What is PATRIC?</h1>
 
     <section class="main">
         <div class="data-box">

--- a/content/burkholderia_pseudomallei_transcriptome_compendium
+++ b/content/burkholderia_pseudomallei_transcriptome_compendium
@@ -1,7 +1,7 @@
 <div class="dlp">
-    <h2>
+    <h1>
         Burkholderia Pseudomallei Transcriptome Compendium
-    </h2>
+    </h1>
     <section class="main">
         <div class="data-box">
 

--- a/content/center-for-systems-biology-of-enteropathogens-sysbep
+++ b/content/center-for-systems-biology-of-enteropathogens-sysbep
@@ -1,7 +1,7 @@
 <div class="dlp">
-    <h2>
+    <h1>
         Center For Systems Biology of Enteropathogens Sysbep
-    </h2>
+    </h1>
     <section class="main">
         <div class="data-box">
 
@@ -252,7 +252,7 @@
                                                          target="_blank">PNNL_1063</a></li>
             </ul>
         </div>
-        <h2>Host Response Data</h2>
+        <h1>Host Response Data</h1>
         <div class="data-box">
 
             <h3 class="ribbon-title">Mouse Macrophage</h3>

--- a/content/cli_intro
+++ b/content/cli_intro
@@ -1,5 +1,5 @@
 <div class="dlp">
- <H2>Introduction to the Patric Command Line Interface (CLI)</H2>
+ <h1>Introduction to the Patric Command Line Interface (CLI)</h1>
  <section class="main">
   <div class="data-box">
 
@@ -73,7 +73,7 @@ Here, we retrieved the id of all genomes in Patric, piped that output to get the
 <br>
 There are other ways to accomplish this, but the example serves to demonstrate what we mean by creating pipelines of commands and producing tables of information. 
 <br>
-<H2> Accessing Features</H2>
+<h1> Accessing Features</h1>
 If you want to look into the features of a genome, you would use the p3-get-genome-features command. p3-genome-features takes as input a set of genome ids. The following example uses the p3-echo command to generate input for p3-get-genome-features.
 <pre>
 <b>p3-echo -t genome.genome_id 282669.3 | p3-get-genome-features | head </b>

--- a/content/collaborators
+++ b/content/collaborators
@@ -1,7 +1,7 @@
 <div class="dlp">
-    <h2>
+    <h1>
         Scientific Collaborations
-    </h2>
+    </h1>
 
     <section class="main">
         <p>Click <a href="/content/patric-publications">here</a> for a list of PATRIC joint publications with other

--- a/content/dlp/AntibioticResistance
+++ b/content/dlp/AntibioticResistance
@@ -1,6 +1,5 @@
 <div class="dlp">
-	<span>Data</span>
-    	<h2>Antimicrobial Resistance (AMR)</h2>
+  <h1>Antimicrobial Resistance (AMR)</h1>
 	<section class="main">
 	
 	<!-- Section: Data -->

--- a/content/dlp/Genomes
+++ b/content/dlp/Genomes
@@ -1,6 +1,5 @@
 <div class="dlp">
-    <span>Data</span>
-    <h2>Genomes</h2>
+  <h1>Genomes</h1>
 	<section class="main">
 		<!-- Section: Data -->
 		<div class="data-tab" id="tab1">

--- a/content/dlp/GenomicFeatures
+++ b/content/dlp/GenomicFeatures
@@ -1,6 +1,5 @@
 <div class="dlp">
-    <span>Data</span>
-    <h2>Genomic Features</h2>
+    <h1>Genomic Features</h1>
     <section class="main">
         <!-- Section: Data -->
         <div class="data-tab" id="tab1">

--- a/content/dlp/Pathways
+++ b/content/dlp/Pathways
@@ -1,6 +1,5 @@
 <div class="dlp">
-	<span>Data</span>
-    <h2>Pathways</h2>
+  <h1>Pathways</h1>
 	<section class="main">
 		<!-- Section: Data -->
 		<div class="data-tab" id="tab1">

--- a/content/dlp/ProteinFamilies
+++ b/content/dlp/ProteinFamilies
@@ -1,6 +1,5 @@
 <div class="dlp">
-	<span>Data</span>
-    <h2>Protein Families</h2>
+  <h1>Protein Families</h1>
 	<section class="main">
 
 		<!-- Section: Data -->

--- a/content/dlp/SpecialtyGenes
+++ b/content/dlp/SpecialtyGenes
@@ -1,6 +1,5 @@
 <div class="dlp">
-    <span>Data</span>
-    <h2>Specialty Genes</h2>
+  <h1>Specialty Genes</h1>
 	<section class="main">
 		<!-- Section: Data -->
 		<div class="data-tab" id="tab1">

--- a/content/dlp/Transcriptomics
+++ b/content/dlp/Transcriptomics
@@ -1,6 +1,5 @@
 <div class="dlp">
-	<span>Data</span>
-    <h2>Transcriptomics</h2>
+  <h1>Transcriptomics</h1>
 	<section class="main">
 		<!-- Section: Data -->
 		<div class="data-tab" id="tab1">

--- a/content/flute-data-set-1
+++ b/content/flute-data-set-1
@@ -1,7 +1,7 @@
 <div class="dlp">
-    <h2>
+    <h1>
         Flute Data Set 1
-    </h2>
+    </h1>
     <section class="main">
         <div class="data-box">
 

--- a/content/flute-experiment-2
+++ b/content/flute-experiment-2
@@ -1,7 +1,7 @@
 <div class="dlp">
-    <h2>
+    <h1>
         FLUTE Experiment 2
-    </h2>
+    </h1>
     <section class="main">
         <div class="data-box">
             <h3><strong>Peptidoglycan synthesis in Mycobacterium tuberculosis is organized into networks with varying

--- a/content/flute-experiment-3
+++ b/content/flute-experiment-3
@@ -1,7 +1,7 @@
 <div class="dlp">
-    <h2>
+    <h1>
         FLUTE Experiment 3
-    </h2>
+    </h1>
     <section class="main">
         <div class="data-box">
 

--- a/content/flute-experiment-4
+++ b/content/flute-experiment-4
@@ -1,7 +1,7 @@
 <div class="dlp">
-    <h2>
+    <h1>
         FLUTE Experiment 4
-    </h2>
+    </h1>
     <section class="main">
         <div class="data-box">
 

--- a/content/flute-experiment-5
+++ b/content/flute-experiment-5
@@ -1,8 +1,8 @@
 
 <div class="dlp">
-    <h2>
+    <h1>
         FLUTE Experiment 5
-    </h2>
+    </h1>
     <section class="main">
         <div class="data-box">
 

--- a/content/functionalizing-lists-of-unknown-tb-entities-flute
+++ b/content/functionalizing-lists-of-unknown-tb-entities-flute
@@ -1,7 +1,7 @@
 <div class="dlp">
-    <h2>
+    <h1>
         Functionalizing Lists of Unknown TB Entitites - FLUTE
-    </h2>
+    </h1>
     <section class="main">
         <div class="data-box">
             <p><img class="alignnone size-full wp-image-4738" src="/public/patric/images/FLUTE_logo_blue.png"

--- a/content/genes-unknown-in-acinetobacter-baumannii-gunk
+++ b/content/genes-unknown-in-acinetobacter-baumannii-gunk
@@ -1,7 +1,7 @@
 <div class="dlp">
-    <h2>
+    <h1>
         Genes Unknown in Acintetobacter Baumannii - GUNK
-    </h2>
+    </h1>
     <section class="main">
         <div class="data-box">
 

--- a/content/gunk-experiment-1
+++ b/content/gunk-experiment-1
@@ -1,7 +1,7 @@
 <div class="dlp">
-    <h2>
+    <h1>
         GUNK Experiment 1
-    </h2>
+    </h1>
     <section class="main">
         <div class="data-box">
             <p><strong>Resources for Genetic and Genomic Analysis of Emerging Pathogen Acinetobacter baumannii</strong>

--- a/content/gunk-experiment-2
+++ b/content/gunk-experiment-2
@@ -1,7 +1,7 @@
 <div class="dlp">
-    <h2>
+    <h1>
         GUNK Experiement 2
-    </h2>
+    </h1>
     <section class="main">
         <div class="data-box">
             <p><strong>Host-Microbe Protein Interactions during Bacterial Infection</strong></p>
@@ -25,14 +25,14 @@
                 PI/Lab: James Bruce, University of Washington<br>
                 Uploaded/Deposited by: Devon Schweppe, University of Washington</p>
             <p><strong>Protein-Protein Interaction Datasets:</strong></p>
-            <p><em>In&nbsp;vivo</em> proteomic XL-MS analysis of proteins from infected H292 lung epithelial cells
+            <p><em>In&nbsp;vivo</em> proteomic XL-MS analysis of proteins from infected h192 lung epithelial cells
                 generated 16,758 crosslinked peptide-peptide relationships. Of these, we identified 3,076 non-redundant
                 peptide-peptide relationships across three biological replicates at a relationship false discovery rate
                 (FDR) of 0.24%. Crosslinked peptide-peptide relationships were mapped to a network of 715
                 protein-protein interactions (PPIs) attributed to 488 human proteins and 113 bacterial proteins.</p>
             <p><a href="http://enews.patricbrc.org/wp-content/uploads/2016/03/mmc2-1.xlsx">Table S1</a> –&nbsp;All
                 Crosslinked Peptide/Site Relationships Identified across Thre Biological Replicates of for
-                Ab5075-Infected H292 Cells</p>
+                Ab5075-Infected h192 Cells</p>
             <p>In addition to crosslinking infected host cells, we harvested AB5075 alone and crosslinked the bacterial
                 cells to improve network and structural coverage of bacterial interprotein and intraprotein crosslinks
                 within AB5075.</p>

--- a/content/gunk-experiment-2
+++ b/content/gunk-experiment-2
@@ -25,14 +25,14 @@
                 PI/Lab: James Bruce, University of Washington<br>
                 Uploaded/Deposited by: Devon Schweppe, University of Washington</p>
             <p><strong>Protein-Protein Interaction Datasets:</strong></p>
-            <p><em>In&nbsp;vivo</em> proteomic XL-MS analysis of proteins from infected h192 lung epithelial cells
+            <p><em>In&nbsp;vivo</em> proteomic XL-MS analysis of proteins from infected H292 lung epithelial cells
                 generated 16,758 crosslinked peptide-peptide relationships. Of these, we identified 3,076 non-redundant
                 peptide-peptide relationships across three biological replicates at a relationship false discovery rate
                 (FDR) of 0.24%. Crosslinked peptide-peptide relationships were mapped to a network of 715
                 protein-protein interactions (PPIs) attributed to 488 human proteins and 113 bacterial proteins.</p>
             <p><a href="http://enews.patricbrc.org/wp-content/uploads/2016/03/mmc2-1.xlsx">Table S1</a> –&nbsp;All
                 Crosslinked Peptide/Site Relationships Identified across Thre Biological Replicates of for
-                Ab5075-Infected h192 Cells</p>
+                Ab5075-Infected H292 Cells</p>
             <p>In addition to crosslinking infected host cells, we harvested AB5075 alone and crosslinked the bacterial
                 cells to improve network and structural coverage of bacterial interprotein and intraprotein crosslinks
                 within AB5075.</p>

--- a/content/niaid-antimicrobial-resistance-sequencing-projects
+++ b/content/niaid-antimicrobial-resistance-sequencing-projects
@@ -1,7 +1,7 @@
 <div class="dlp">
-    <h2>
+    <h1>
         NIAID Antimicrobial Resistance Sequencing Projects
-    </h2>
+    </h1>
     <section class="main">
         <div class="data-box">
             <h3 class="ribbon-title">NIAID Antimicrobial Resistance Sequencing Projects</h3>

--- a/content/niaid-clinical-proteomics
+++ b/content/niaid-clinical-proteomics
@@ -1,6 +1,5 @@
 <div class="dlp">
-    <span>Data</span>
-    <h2>NIAID Clinical Proteomics</h2>
+    <h1>NIAID Clinical Proteomics</h1>
     <section class="main">
         <div class="data-box">
             <p>The Clinical Proteomics Centers for Infectious Diseases and Biodefense apply state-of-the-art proteomics

--- a/content/niaid-functional-genomics
+++ b/content/niaid-functional-genomics
@@ -1,8 +1,5 @@
 <div class="dlp">
-    <span>Data</span>
-    <h2>
-        NIAID Functional Genomics
-    </h2>
+    <h1>NIAID Functional Genomics</h1>
     <section class="main">
         <div class="data-box">
             <p>The Functional Genomics Program for understanding the functions of uncharacterized genes in infectious

--- a/content/niaid-genome-sequencing
+++ b/content/niaid-genome-sequencing
@@ -1,6 +1,5 @@
 <div class="dlp">
-    <span>Data</span>
-    <h2>NIAID Genomic Sequencing</h2>
+    <h1>NIAID Genomic Sequencing</h1>
     <section class="main">
 
         <div class="data-box">

--- a/content/niaid-structural-genomics
+++ b/content/niaid-structural-genomics
@@ -1,6 +1,5 @@
 <div class="dlp">
-    <span>Data</span>
-    <h2>NIAID Structural Genomics</h2>
+    <h1>NIAID Structural Genomics</h1>
     <section class="main">
     <div class="data-box">
         <h3 class="ribbon-title">Structural Genomics Centers for Infectious Diseases</h3>

--- a/content/niaid-systems-biology
+++ b/content/niaid-systems-biology
@@ -1,6 +1,5 @@
 <div class="dlp">
-    <span>Data</span>
-    <h2>NIAID Systems Biology</h2>
+    <h1>NIAID Systems Biology</h1>
     <section class="main">
     <div class="data-box">
         <p>The NIAID Systems Biology for Infectious Diseases Research Program develops and validates predictive models

--- a/content/omics4tb
+++ b/content/omics4tb
@@ -1,6 +1,5 @@
 <div class="dlp">
-    <span>Data > NIAID Systems Biology</span>
-    <h2>Omics4TB</h2>
+    <h1>Omics4TB</h1>
     <section class="main">
         <div class="data-box">
 

--- a/content/omics4tb-chip-seq-experiments
+++ b/content/omics4tb-chip-seq-experiments
@@ -1,5 +1,5 @@
 <div class="dlp">
-    <h2>Omics4TB ChIP-Seq Experiments</h2>
+    <h1>Omics4TB ChIP-Seq Experiments</h1>
 
     <section class="main">
         <div class="data-box">

--- a/content/omics4tb-macrophage-mtb_infection
+++ b/content/omics4tb-macrophage-mtb_infection
@@ -1,7 +1,7 @@
 
 <div class="dlp">
 
-    <h2>Omics4TB: MiR-155-regulated molecular network orchestrates cell fate in the innate and adaptive immune response to Mycobacterium tuberculosis.</h2>
+    <h1>Omics4TB: MiR-155-regulated molecular network orchestrates cell fate in the innate and adaptive immune response to Mycobacterium tuberculosis.</h1>
     <section class="main">
         <div class="data-box">
         

--- a/content/omics4tb-mtb-bedaquiline-tolerance
+++ b/content/omics4tb-mtb-bedaquiline-tolerance
@@ -1,7 +1,7 @@
 
 <div class="dlp">
 
-    <h2>Omics4TB: Network analysis identifies Rv0324 and Rv0880 as regulators of bedaquiline tolerance in Mycobacterium tuberculosis.</h2>
+    <h1>Omics4TB: Network analysis identifies Rv0324 and Rv0880 as regulators of bedaquiline tolerance in Mycobacterium tuberculosis.</h1>
     <section class="main">
         <div class="data-box">
         

--- a/content/omics4tb-tfoe-expression-experiments
+++ b/content/omics4tb-tfoe-expression-experiments
@@ -1,6 +1,6 @@
 <div class="dlp">
 
-    <h2>Omics4TB TFOE Expression Experiments</h2>
+    <h1>Omics4TB TFOE Expression Experiments</h1>
     <section class="main">
 
         <div class="data-box">

--- a/content/patric-collaborations
+++ b/content/patric-collaborations
@@ -1,6 +1,5 @@
 <div class="dlp">
-    <span>Data</span>
-    <h2>PATRIC Collaborations</h2>
+    <h1>PATRIC Collaborations</h1>
     <section class="main">
         <div class="data-box">
             <p>The opportunity to collaborate on various projects enables the team to understand and drive important

--- a/content/patric-dbp-mcclelland
+++ b/content/patric-dbp-mcclelland
@@ -1,5 +1,5 @@
 <div class="dlp">
-    <h2>PATRIC DBP - McClelland</h2>
+    <h1>PATRIC DBP - McClelland</h1>
 
     <section class="main">
         <div class="data-box">

--- a/content/patric-dbps
+++ b/content/patric-dbps
@@ -1,6 +1,5 @@
 <div class="dlp">
-    <span>Data</span>
-    <h2>PATRIC-DBPs</h2>
+    <h1>PATRIC-DBPs</h1>
 
     <section class="main">
         <div class="data-box">

--- a/content/personnel
+++ b/content/personnel
@@ -1,5 +1,5 @@
 <div class="dlp">
-    <h2>PATRIC Personnel</h2>
+    <h1>PATRIC Personnel</h1>
     <section class="main">
         <div class="data-box popular-box tabbed hover-tabs no-underline-links">
             <h3 class="ribbon-title">University of Chicago / Argonne National Laboratory / FIG</h3>

--- a/content/predicting-the-emergence-of-antibiotic-resistance-through-multi-omics-approaches-and-immune-system-surveillance
+++ b/content/predicting-the-emergence-of-antibiotic-resistance-through-multi-omics-approaches-and-immune-system-surveillance
@@ -1,7 +1,7 @@
 <div class="dlp">
-    <h2>
+    <h1>
         PREDICTING THE EMERGENCE OF ANTIBIOTIC RESISTANCE THROUGH MULTI-OMICS APPROACHES AND IMMUNE SYSTEM-SURVEILLANCE
-    </h2>
+    </h1>
     <section class="main">
         <div class="data-box">
             <p><strong>Title:</strong> PREDICTING THE EMERGENCE OF ANTIBIOTIC RESISTANCE THROUGH MULTI-OMICS APPROACHES

--- a/content/presentations
+++ b/content/presentations
@@ -1,5 +1,5 @@
 <div class="dlp">
-    <h2>PATRIC Presentations</h2>
+    <h1>PATRIC Presentations</h1>
     <section class="main">
 
         <div class="data-box">

--- a/content/publications
+++ b/content/publications
@@ -1,5 +1,5 @@
 <div class="dlp">
-    <h2>PATRIC Publications</h2>
+    <h1>PATRIC Publications</h1>
     <section class="main">
 
         <div class="data-box">

--- a/content/related_sites
+++ b/content/related_sites
@@ -1,5 +1,5 @@
 <div class="dlp">
-    <h2>Related Sites</h2>
+    <h1>Related Sites</h1>
 
     <section class="main">
         <div class="data-box">

--- a/content/systems-biology-approach-to-redefine-susceptibility-testing-and-treatment-of-amr-pathogens-in-the-context-of-host-immunity
+++ b/content/systems-biology-approach-to-redefine-susceptibility-testing-and-treatment-of-amr-pathogens-in-the-context-of-host-immunity
@@ -1,8 +1,8 @@
 <div class="dlp">
-    <h2>
+    <h1>
         SYSTEMS BIOLOGY APPROACH TO REDEFINE SUSCEPTIBILITY TESTING AND TREATMENT OF MDR PATHOGENS IN THE CONTEXT OF
         HOST IMMUNITY
-    </h2>
+    </h1>
     <section class="main">
         <div class="data-box">
             <p><strong>Title:</strong> SYSTEMS BIOLOGY APPROACH TO REDEFINE SUSCEPTIBILITY TESTING AND TREATMENT OF MDR

--- a/content/systems-biology-of-clostridium-difficile-infection
+++ b/content/systems-biology-of-clostridium-difficile-infection
@@ -1,7 +1,7 @@
 <div class="dlp">
-    <h2>
+    <h1>
         SYSTEMS BIOLOGY OF CLOSTRIDIUM DIFFICILE INFECTION
-    </h2>
+    </h1>
     <section class="main">
         <div class="data-box">
             <p><strong>Title:</strong> SYSTEMS BIOLOGY OF CLOSTRIDIUM DIFFICILE INFECTION<br>

--- a/content/systems-biology-of-microbiome-mediated-resilience-to-antibiotic-resistance-pathogens
+++ b/content/systems-biology-of-microbiome-mediated-resilience-to-antibiotic-resistance-pathogens
@@ -1,7 +1,7 @@
 <div class="dlp">
-    <h2>
+    <h1>
         SYSTEMS BIOLOGY OF MICROBIOME-MEDIATED RESILIENCE TO ANTIBIOTIC-RESISTANT PATHOGENS
-    </h2>
+    </h1>
     <section class="main">
         <div class="data-box">
             <p><strong>Title:</strong> SYSTEMS BIOLOGY OF MICROBIOME-MEDIATED RESILIENCE TO ANTIBIOTIC-RESISTANT

--- a/content/systems-immunolobiology-of-antibiotic-persistent-mrsa-infection
+++ b/content/systems-immunolobiology-of-antibiotic-persistent-mrsa-infection
@@ -1,7 +1,7 @@
 <div class="dlp">
-    <h2>
+    <h1>
         SYSTEMS IMMUNOLOBIOLOGY OF ANTIBIOTIC-PERSISTENT MRSA INFECTION
-    </h2>
+    </h1>
     <section class="main">
         <div class="data-box">
             <p><strong>Title:</strong> SYSTEMS IMMUNOLOBIOLOGY OF ANTIBIOTIC-PERSISTENT MRSA INFECTION<br>

--- a/content/tb-arc-tb-antibiotic-resistance-catalog
+++ b/content/tb-arc-tb-antibiotic-resistance-catalog
@@ -1,7 +1,7 @@
 <div class="dlp">
-    <h2>
+    <h1>
         TB-ARC Antibiotic Resistance Catalog
-    </h2>
+    </h1>
     <section class="main">
         <div class="data-box">
             <p>&nbsp;</p>

--- a/content/tb-systems-biology
+++ b/content/tb-systems-biology
@@ -1,6 +1,5 @@
 <div class="dlp">
-    <span>Data > NIAID Systems Biology</span>
-    <h2>TB Systems Biology</h2>
+    <h1>TB Systems Biology</h1>
     <section class="main">
         <div class="data-box">
 

--- a/content/the-chicago-center-for-functional-annotation-ccfa
+++ b/content/the-chicago-center-for-functional-annotation-ccfa
@@ -1,7 +1,7 @@
 <div class="dlp">
-    <h2>
+    <h1>
         The Chicago Center for Functional Annotation (CCFA)
-    </h2>
+    </h1>
     <section class="main">
         <div class="data-box">
             <p><img class="aligncenter size-full wp-image-4828"

--- a/content/workshops
+++ b/content/workshops
@@ -1,5 +1,5 @@
 <div class="dlp">
-    <h2>PATRIC Workshops</h2>
+    <h1>PATRIC Workshops</h1>
     <section class="main">
 
         <div class="data-box">


### PR DESCRIPTION
Updated content pages to have H1 tags instead of H2. The 'dlp.css' stylesheet was also updated in the p3_web repo. 

Markdown files should use a single # instead of ## for page headers if used. 