### PR TITLE
Prevent fasta early stopping

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The following operators are available for RQL Queries:
 
 HTTP Headers can be supplied normally or in a url by preceding the header name with "http_".  (e.g., &http_accept=application/json)
 
-Requests can force the server to set content-dispostion (thereby forcing a browser to download the file) by adding &http_download onto the url.
+Requests can force the server to set content-dispostion (thereby forcing a browser to download the file) by adding &http_download=true onto the url.
+This must be used in combination with sort(+UNIQUE_KEY) to increase the download limit to 25 million records.
 
 

--- a/media/protein+fasta.js
+++ b/media/protein+fasta.js
@@ -11,7 +11,7 @@ function formatFASTA (doc) {
     fasta_id = `gi|${doc.gi}|${(doc.refseq_locus_tag ? (doc.refseq_locus_tag + '|') : '') + (doc.alt_locus_tag ? (doc.alt_locus_tag + '|') : '')}`
   }
   const header = `>${fasta_id} ${doc.product} [${doc.genome_name} | ${doc.genome_id}]\n`
-  return header + ((doc.sequence) ? LineWrap(doc.sequence, 60) : '') + '\n'
+  return header + ((doc.sequence) ? LineWrap(doc.sequence, 60) + '\n' : '')
 }
 
 module.exports = {
@@ -30,7 +30,7 @@ module.exports = {
         if (!results.stream) {
           throw Error('Expected ReadStream in Serializer')
         }
-
+        var errs=[];
         results.stream.pipe(EventStream.map(function (data, callback) {
           if (!head) {
             head = data
@@ -42,10 +42,15 @@ module.exports = {
               // docCount++
               callback()
             }).catch((err) => {
-              next(new Error(err))
+              //res.write(formatFASTA(data))
+              errs.push(formatFASTA(data))
+              callback()
             })
           }
         })).on('end', function () {
+          if (errs.length>0) {
+            res.write(errs.join(""));
+          }
           res.end()
         })
       }, (error) => {

--- a/middleware/http-params.js
+++ b/middleware/http-params.js
@@ -49,7 +49,6 @@ module.exports = function (req, res, next) {
     req._parsedUrl.query = ''
   }
 
-  req.isDownload = !!(req.headers && req.headers.download)
   debug('End http-params Middleware: ', req._parsedUrl, req._parsedUrl.query)
 
   next()

--- a/middleware/http-params.js
+++ b/middleware/http-params.js
@@ -49,6 +49,7 @@ module.exports = function (req, res, next) {
     req._parsedUrl.query = ''
   }
 
+  req.isDownload = !!(req.headers && req.headers.download)
   debug('End http-params Middleware: ', req._parsedUrl, req._parsedUrl.query)
 
   next()


### PR DESCRIPTION

This change prevents FASTA download early stopping when a sequence record lacks a sequence.

This can be observed via

curl "https://patricbrc.org/api/genome_feature/?and(eq(feature_type,CDS),eq(annotation,PATRIC),in(genome_id,(106654.48)))&limit(25000000)&sort(+feature_id)&http_accept=application/protein+fasta&http_download=true" >test_missing_prod.fasta

empty fasta records are appended to the end of the request but still allow the user to retrieve the data.