### PR TITLE
Auth fix for private genomes on BV-BRC site

### DIFF
--- a/routes/dataType.js
+++ b/routes/dataType.js
@@ -21,6 +21,23 @@ const ShardsPreference = require('../middleware/ShardsPreference')
 
 router.use(httpParams)
 
+// Extract http_authorization from POST body before auth middleware runs
+// This allows form-based downloads to pass authorization securely via POST body
+// instead of URL query parameters (which can be logged/cached)
+router.use(bodyParser.urlencoded({ extended: false, limit: '1mb' }))
+router.use(function (req, res, next) {
+  if (req.method === 'POST' && req.body && req.body.http_authorization) {
+    // Only set header if not already present
+    if (!req.headers['authorization']) {
+      req.headers['authorization'] = req.body.http_authorization
+      debug('Set authorization header from POST body http_authorization')
+    }
+    // Remove from body to prevent it from being processed further
+    delete req.body.http_authorization
+  }
+  next()
+})
+
 router.use(authMiddleware)
 
 router.use(PublicDataTypes)


### PR DESCRIPTION
 The website code is correct - it sends http_authorization as a hidden form field in the POST body (lines 75-80).

  Summary of the fix:

  The download functionality for private genomes wasn't working because:

  1. Security fix blocked http_authorization in URL: The p3_api had a security fix that blocked http_authorization from being set via query parameters (only accept, range, content-type are whitelisted in http-params.js)
  2. Auth middleware ran before body parsing: The authorization check in auth.js ran before the POST body was parsed, so even though the website was sending http_authorization in the POST body, it was never read

  The fix in p3_api (routes/dataType.js):

  I added middleware that:
  1. Parses the URL-encoded POST body before the auth middleware runs
  2. Extracts http_authorization from the body and sets it as the Authorization header
  3. Removes it from the body to prevent further processing

  To test the fix:

  1. Restart the p3_api server: npm start (or however you restart it)
  2. Restart the website server if needed
  3. Clear browser cache / hard refresh
  4. Try downloading a table with private genomes

  The authorization token will now be:
  - Sent securely via POST body (not exposed in URLs)
  - Extracted by the new middleware
  - Set as the Authorization header before auth middleware runs
  - Properly validated to allow access to private genomes