### PR TITLE
Add access control filtering for protein_structure queries

### DIFF
--- a/middleware/DecorateQuery.js
+++ b/middleware/DecorateQuery.js
@@ -1,13 +1,26 @@
+// Collections that need join-based access control (they reference genomes but don't have their own permission fields)
+const joinAccessControlCollections = {
+  protein_structure: { fromIndex: 'genome', from: 'genome_id', to: 'genome_id' }
+}
+
 module.exports = function (req, res, next) {
   if (req.call_method !== 'query') { return next() }
 
   req.call_params[0] = req.call_params[0] || '&q=*:*'
-  if (!req.user) {
-    if (!req.publicFree || (req.publicFree && (req.publicFree.indexOf(req.call_collection) < 0))) {
-      req.call_params[0] = req.call_params[0] + '&fq=public:true'
+
+  // Check if this collection needs join-based access control
+  const joinConfig = joinAccessControlCollections[req.call_collection]
+  if (joinConfig) {
+    // Use a Solr cross-collection join to filter by the referenced collection's access control
+    if (!req.user) {
+      req.call_params[0] = req.call_params[0] + `&fq={!join method=crossCollection from=${joinConfig.from} to=${joinConfig.to} fromIndex=${joinConfig.fromIndex}}public:true`
+    } else {
+      req.call_params[0] = req.call_params[0] + `&fq={!join method=crossCollection from=${joinConfig.from} to=${joinConfig.to} fromIndex=${joinConfig.fromIndex}}(public:true OR owner:${req.user} OR user_read:${req.user})`
     }
-  } else {
-    if (!req.publicFree || (req.publicFree && (req.publicFree.indexOf(req.call_collection) < 0))) {
+  } else if (!req.publicFree || (req.publicFree && (req.publicFree.indexOf(req.call_collection) < 0))) {
+    if (!req.user) {
+      req.call_params[0] = req.call_params[0] + '&fq=public:true'
+    } else {
       req.call_params[0] = req.call_params[0] + ('&fq=(public:true OR owner:' + req.user + ' OR user_read:' + req.user + ')')
     }
   }

--- a/middleware/PublicDataTypes.js
+++ b/middleware/PublicDataTypes.js
@@ -1,5 +1,5 @@
 
-const publicFree = ['antibiotics', 'enzyme_class_ref', 'epitope', 'epitope_assay', 'experiment', 'bioset', 'bioset_result', 'gene_ontology_ref', 'id_ref', 'misc_niaid_sgc', 'pathway_ref', 'ppi', 'pig', 'protein_family_ref', 'sp_gene_evidence', 'sp_gene_ref', 'spike_lineage', 'spike_variant', 'subsystem_ref', 'taxonomy', 'transcriptomics_experiment', 'transcriptomics_gene', 'transcriptomics_sample', 'model_reaction', 'model_complex_role', 'model_compound', 'model_template_biomass', 'model_template_reaction', 'feature_sequence', 'protein_structure', 'protein_feature', 'surveillance', 'serology', 'sequence_feature', 'sequence_feature_vt']
+const publicFree = ['antibiotics', 'enzyme_class_ref', 'epitope', 'epitope_assay', 'experiment', 'bioset', 'bioset_result', 'gene_ontology_ref', 'id_ref', 'misc_niaid_sgc', 'pathway_ref', 'ppi', 'pig', 'protein_family_ref', 'sp_gene_evidence', 'sp_gene_ref', 'spike_lineage', 'spike_variant', 'subsystem_ref', 'taxonomy', 'transcriptomics_experiment', 'transcriptomics_gene', 'transcriptomics_sample', 'model_reaction', 'model_complex_role', 'model_compound', 'model_template_biomass', 'model_template_reaction', 'feature_sequence', 'protein_feature', 'surveillance', 'serology', 'sequence_feature', 'sequence_feature_vt']
 
 module.exports = function (req, res, next) {
   req.publicFree = publicFree


### PR DESCRIPTION
## Summary
- Remove protein_structure from the publicFree list in PublicDataTypes.js
- Add join-based access control in DecorateQuery.js for collections that reference genomes but do not have their own permission fields
- Uses Solr cross-collection join to filter protein_structure results based on the associated genome access permissions

## Problem
Protein structure records were being returned without access control checks. Since protein_structure was in the publicFree list, queries would return structures linked to private genomes that users should not have access to.

## Solution
Implement join-based access control that:
- For anonymous users: Only returns structures where the linked genome has public:true
- For authenticated users: Returns structures where the linked genome is public OR owned by the user OR shared with the user

## Files Changed
- middleware/PublicDataTypes.js - Removed protein_structure from publicFree array
- middleware/DecorateQuery.js - Added joinAccessControlCollections config and logic for join-based filtering

## Related
This PR should be deployed alongside BV-BRC/BV-BRC-Web#1221 which adds the UI for creating genome/feature groups from protein structure selections.

## Test plan
- [ ] Query protein_structure as anonymous user - should only see structures from public genomes
- [ ] Query protein_structure as authenticated user - should see structures from public genomes and private genomes they own/have access to
- [ ] Verify structures from other users private genomes are not visible

Generated with Claude Code