### PR TITLE
Optimize query limits for fixed ID list queries

### DIFF
--- a/middleware/Limiter.js
+++ b/middleware/Limiter.js
@@ -1,6 +1,39 @@
-const MAX_LIMIT = 25000
+const MAX_LIMIT = 50000
 const DEFAULT_LIMIT = 25
 const DOWNLOAD_LIMIT = 2500000
+const ID_COUNT_BUFFER = 10
+
+/**
+ * Detect queries with fixed ID lists and return the count of IDs.
+ * Matches patterns like: field:(id1 OR id2 OR id3...)
+ * This helps optimize queries where we know the maximum possible results.
+ *
+ * @param {string} query - The Solr query string
+ * @returns {number|null} - The count of IDs if detected, null otherwise
+ */
+function detectFixedIdCount (query) {
+  if (!query) return null
+
+  // Match patterns like: field:(val1 OR val2 OR val3) or field:(val1+OR+val2+OR+val3)
+  // Common fields: md5, genome_id, feature_id, patric_id, id, subsystem_id
+  const orPattern = /\b(md5|genome_id|feature_id|patric_id|id|subsystem_id):\(([^)]+)\)/gi
+
+  let maxIdCount = 0
+
+  let match
+  while ((match = orPattern.exec(query)) !== null) {
+    const idsClause = match[2]
+    // Count OR separators (handles both " OR " and "+OR+")
+    const orCount = (idsClause.match(/(\+OR\+|\sOR\s)/gi) || []).length
+    // Number of IDs = OR count + 1
+    const idCount = orCount + 1
+    if (idCount > maxIdCount) {
+      maxIdCount = idCount
+    }
+  }
+
+  return maxIdCount > 1 ? maxIdCount : null
+}
 
 module.exports = function (req, res, next) {
   if (req.call_method !== 'query') { return next() }
@@ -45,6 +78,17 @@ module.exports = function (req, res, next) {
     req.call_params[0] = q.replace(rowsRegMatches[0], '&rows=' + limit)
   } else {
     req.call_params[0] = req.call_params[0] + '&rows=' + limit
+  }
+
+  // Check for fixed ID list queries and cap limit if appropriate
+  const idCount = detectFixedIdCount(req.call_params[0])
+  if (idCount) {
+    const idBasedLimit = idCount + ID_COUNT_BUFFER
+    if (idBasedLimit < limit) {
+      console.log(`[Limiter] Fixed ID query detected: ${idCount} IDs, capping limit from ${limit} to ${idBasedLimit}`)
+      req.call_params[0] = req.call_params[0].replace(/&rows=\d+/, '&rows=' + idBasedLimit)
+      limit = idBasedLimit
+    }
   }
 
   if (queryOffset) {

--- a/util/featureSequence.js
+++ b/util/featureSequence.js
@@ -56,7 +56,7 @@ async function _getSequenceDictByHash (md5Array) {
 async function getSequenceDictByHash (md5Array,req) { 
   // console.log("getSequenDictByHash")
   const ids = md5Array.join(',')
-  const q = `&in(md5,(${ids}))&limit(9999)&select(md5,sequence)` 
+  const q = `&in(md5,(${ids}))&limit(${md5Array.length})&select(md5,sequence)` 
 
   // console.log("query: ", q)
   if (distributeURL.charAt(distributeURL.length-1)=="/"){


### PR DESCRIPTION
## Summary

- Detect queries with fixed identifier lists (e.g., `md5:(id1 OR id2 OR id3...)`) and cap the rows limit to match the number of IDs plus a small buffer (10)
- Prevents excessive memory allocation in Solr when queries can never return more results than the number of IDs requested
- Increases MAX_LIMIT from 25000 to 50000
- Fixes `featureSequence.js` to use actual array length instead of hardcoded 9999

This addresses Solr OOM crashes caused by queries requesting `rows=10000000` when only fetching ~100 documents by ID.

## Test plan

- [ ] Verify queries with fixed ID lists get appropriate row limits (check server logs for `[Limiter] Fixed ID query detected` messages)
- [ ] Verify normal queries without ID lists still work as expected
- [ ] Verify sequence lookups via `getSequenceDictByHash()` use correct limits

🤖 Generated with [Claude Code](https://claude.com/claude-code)