### PR TITLE
Add request ID to standard API access logs

### DIFF
--- a/app.js
+++ b/app.js
@@ -23,6 +23,12 @@ var sleep = require("sleep-promise");
 
 
 var cors = require('cors')
+var crypto = require('crypto')
+
+// Generate request ID for all requests (used for log correlation)
+function generateRequestId () {
+  return 'p3api-' + crypto.randomBytes(6).toString('hex')
+}
 
 process.on('uncaughtException', (err, origin) => {
   console.log(`Uncaught Expcetion. [${(new Date()).toISOString()}] ${err}, ${origin}`)
@@ -67,7 +73,19 @@ logger.token('remote-ip', function (req, res) {
   return req.headers['x-forwarded-for'] || req.connection.remoteAddress
 })
 
-app.use(logger('[:date[iso]] :remote-ip :method :url :status :response-time [:qtime] ms - :res[content-length] :auth-user'))
+logger.token('request-id', function (req, res) {
+  // Use X-Request-ID from nginx if available, or requestId set by Limiter middleware
+  return req.headers['x-request-id'] || req.requestId || '-'
+})
+
+app.use(logger('[:date[iso]] :remote-ip :method :url :status :response-time [:qtime] ms - :res[content-length] :auth-user rid=:request-id'))
+
+// Set request ID early for all requests (before other middleware)
+app.use(function (req, res, next) {
+  // Use X-Request-ID from nginx if available, otherwise generate one
+  req.requestId = req.headers['x-request-id'] || generateRequestId()
+  next()
+})
 
 app.use(function (req, res, next) {
   debug('APP MODE: ', app.get('env'))

--- a/middleware/Limiter.js
+++ b/middleware/Limiter.js
@@ -2,17 +2,6 @@ const MAX_LIMIT = 50000
 const DEFAULT_LIMIT = 25
 const DOWNLOAD_LIMIT = 2500000
 const ID_COUNT_BUFFER = 10
-const crypto = require('crypto')
-
-// Generate a short unique request ID for tracing, or use one from nginx
-function getRequestId (req) {
-  // Prefer X-Request-ID from nginx if available
-  if (req.headers['x-request-id']) {
-    return req.headers['x-request-id']
-  }
-  // Fall back to generating our own
-  return 'p3api-' + crypto.randomBytes(6).toString('hex')
-}
 
 /**
  * Detect queries with fixed ID lists and return the count of IDs.
@@ -49,9 +38,8 @@ function detectFixedIdCount (query) {
 module.exports = function (req, res, next) {
   if (req.call_method !== 'query') { return next() }
 
-  // Generate request ID for tracing between API and Solr logs
-  const requestId = getRequestId(req)
-  req.requestId = requestId
+  // Use request ID set by app.js middleware
+  const requestId = req.requestId || 'unknown'
 
   let limit = MAX_LIMIT
   const q = req.call_params[0]


### PR DESCRIPTION
## Summary
- Add request ID (`rid=`) to the standard morgan access log format
- Generate request ID early in middleware chain for all requests
- Use `X-Request-ID` from nginx if available, otherwise generate one

## Details
This builds on PR #158 to provide end-to-end request tracing. The access log format now includes the request ID:

```
[2026-04-07T19:43:57.208Z] 98.176.34.83 GET /data/distinct/genome/... 200 1.704 [-] ms - - user@example.org rid=p3api-a1b2c3d4e5f6
```

This request ID can be correlated with:
- Solr logs: `&p3api_rid=p3api-a1b2c3d4e5f6`
- nginx logs (if configured with `X-Request-ID`)

## Test plan
- [ ] Verify access logs include `rid=` field
- [ ] Confirm request ID matches between API logs and Solr logs
- [ ] Test that nginx-provided `X-Request-ID` is used when present

🤖 Generated with [Claude Code](https://claude.com/claude-code)