### PR TITLE
Rename Solr request ID parameter to appRid

### DIFF
--- a/middleware/Limiter.js
+++ b/middleware/Limiter.js
@@ -103,7 +103,8 @@ module.exports = function (req, res, next) {
   }
 
   // Add request ID to query for Solr log correlation
-  req.call_params[0] = req.call_params[0] + '&p3api_rid=' + requestId
+  // Using 'appRid' to avoid conflict with Solr's internal 'rid' parameter
+  req.call_params[0] = req.call_params[0] + '&appRid=' + requestId
 
   // Log summary for feature_sequence queries (debugging OOM issue)
   if (req.call_collection === 'feature_sequence') {


### PR DESCRIPTION
## Summary
Rename the Solr request ID parameter from `p3api_rid` to `appRid` to avoid potential conflict with Solr's internal `rid` parameter.

## Details
Solr uses `rid` internally for distributed query tracking. Using `appRid` ensures our application-level request ID doesn't interfere with Solr's internal mechanisms while still appearing in Solr logs for correlation.

Solr logs will now show: `params={...&appRid=p3api-a1b2c3d4e5f6&...}`

## Test plan
- [x] Verified queries work with the new parameter name
- [ ] Confirm `appRid` appears in Solr logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)