### PR TITLE
Add county and city to editable genome metadata fields

### DIFF
--- a/middleware/patch.js
+++ b/middleware/patch.js
@@ -94,6 +94,8 @@ const userModifiableProperties = [
 	'reference_genome',
 	'season',
 	'state_province',
+	'county',
+	'city',
 	'phenotype'
 ]
 


### PR DESCRIPTION
## Summary
- Add `county` and `city` to the `userModifiableProperties` whitelist in `middleware/patch.js`
- These new MAAGE project genome metadata fields were already included in query/display configuration but were not editable via PATCH requests

## Test plan
- [ ] Verify PATCH requests to update `county` on a genome succeed
- [ ] Verify PATCH requests to update `city` on a genome succeed
- [ ] Verify PATCH requests to non-whitelisted fields still return 406

🤖 Generated with [Claude Code](https://claude.com/claude-code)