### PR TITLE
Fix missing dojo-declare dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "cookie-parser": "~1.3.3",
     "cors": "~2.5.0",
     "debug": "^3.1.0",
+    "dojo-declare": "0.0.1",
     "ejs": "^2.7.4",
     "event-stream": "^3.3.2",
     "express": "^4.16.3",


### PR DESCRIPTION
## Summary

- Add `dojo-declare` to package.json dependencies — required by the inlined `lib/solrjs/index.js` which was previously getting it as a transitive dependency of the external solrjs package

## Test plan

- [ ] `npm install && npm start` succeeds without MODULE_NOT_FOUND error

🤖 Generated with [Claude Code](https://claude.com/claude-code)