### PR TITLE
Fix IDOR in multi-ID get requests

### DIFF
--- a/middleware/APIMethodHandler.js
+++ b/middleware/APIMethodHandler.js
@@ -95,9 +95,16 @@ function getSOLR (req, res, next) {
         }
       } else if (sresults && sresults.response && sresults.response.docs) {
         // handle for multiple ids in get request
-        const results = sresults.response.docs[0]
+        // Check permissions on EVERY document, not just the first
+        const isPublicFree = req.publicFree.indexOf(req.call_collection) >= 0
 
-        if (results.public || (req.publicFree.indexOf(req.call_collection) >= 0) || (results.owner === (req.user)) || (results.user_read && results.user_read.indexOf(req.user) >= 0)) {
+        const authorizedDocs = sresults.response.docs.filter((doc) => {
+          return doc.public || isPublicFree || (doc.owner === req.user) || (doc.user_read && doc.user_read.indexOf(req.user) >= 0)
+        })
+
+        if (authorizedDocs.length > 0) {
+          sresults.response.docs = authorizedDocs
+          sresults.response.numFound = authorizedDocs.length
           res.results = sresults.response
           next()
         } else {


### PR DESCRIPTION
## Summary

- **Security fix**: The multi-ID get path (`GET /:collection/id1,id2,...`) only checked permissions on the first document returned by Solr. An attacker could prepend a public ID to read arbitrary private records from any collection with access controls (genome, genome_sequence, genome_feature, etc.).
- Now filters every document through the same permission check (public flag, publicFree collection, owner match, user_read list) and drops unauthorized documents before returning the response.

## Impact

- Fixes CWE-639 (Authorization Bypass Through User-Controlled Key)
- CVSS 7.5 — unauthenticated network-exploitable data leak of private genome data
- Affects all private collections: genome, genome_sequence, genome_feature, pathway, sp_gene, subsystem, genome_amr, genome_typing

## Test plan

- [ ] `GET /genome/<private_id>` → 401 (unchanged)
- [ ] `GET /genome/<public_id>,<private_id>` → 200 with only the public genome returned
- [ ] `GET /genome/<private_id1>,<private_id2>` unauthenticated → 401
- [ ] `GET /genome/<private_id1>,<private_id2>` as owner → 200 with both returned
- [ ] `GET /genome/<public_id>` → 200 (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)