### PR TITLE
Fix SSRF bypass via double-encoded shards parameter

### DIFF
--- a/middleware/SolrQuerySanitizer.js
+++ b/middleware/SolrQuerySanitizer.js
@@ -41,6 +41,28 @@ const DANGEROUS_PARAMS = [
 const SHARDS_PREFIX_PATTERN = /^shards\./i
 
 /**
+ * Fully decode a string by repeatedly applying decodeURIComponent
+ * until no further decoding is possible. This catches double, triple,
+ * and deeper encoding used to bypass sanitization.
+ * @param {string} str - The string to decode
+ * @returns {string} - Fully decoded string
+ */
+function fullyDecode (str) {
+  if (!str) return str
+  let prev = str
+  for (let i = 0; i < 10; i++) {
+    try {
+      var decoded = decodeURIComponent(prev)
+    } catch (e) {
+      return prev
+    }
+    if (decoded === prev) return decoded
+    prev = decoded
+  }
+  return prev
+}
+
+/**
  * Check if a parameter name is dangerous
  * @param {string} paramName - The parameter name to check
  * @returns {boolean} - True if the parameter is dangerous
@@ -61,8 +83,13 @@ function isDangerousParam (paramName) {
   return false
 }
 
+
 /**
- * Sanitize a query string by removing dangerous parameters
+ * Sanitize a query string by removing dangerous parameters.
+ * Fully decodes the entire string first to catch multi-level encoding
+ * attacks (double, triple, etc.), then rejects the ENTIRE query if any
+ * dangerous parameter is found in the decoded form. This prevents
+ * smuggling via encoded & characters (%26, %2526, etc.).
  * @param {string} queryString - The query string to sanitize
  * @returns {object} - Object with sanitized query and list of blocked params
  */
@@ -71,36 +98,61 @@ function sanitizeQueryString (queryString) {
     return { sanitized: queryString, blockedParams: [] }
   }
 
+  // Fully decode the entire string to catch all encoding levels,
+  // then check for dangerous params in the decoded version.
+  // If ANY dangerous param is found anywhere in the fully-decoded
+  // string, reject the entire query — encoding tricks mean the
+  // whole request is malicious.
+  const fullyDecoded = fullyDecode(queryString)
+  const smuggled = findDangerousParamsInString(fullyDecoded)
+  if (smuggled.length > 0) {
+    debug(`Blocked entire query — dangerous params found after full decode: ${smuggled.join(', ')}`)
+    return { sanitized: '', blockedParams: smuggled }
+  }
+
+  // No encoded tricks detected. Do the standard per-part scan on the
+  // raw query string as a second layer (handles plain-text params).
   const blockedParams = []
   const parts = queryString.split('&')
   const safeParts = []
 
   for (const part of parts) {
-    // Handle both key=value and just key
     const eqIndex = part.indexOf('=')
     const paramName = eqIndex >= 0 ? part.substring(0, eqIndex) : part
 
-    // Decode the parameter name to catch encoded attacks
-    let decodedParamName
-    try {
-      decodedParamName = decodeURIComponent(paramName)
-    } catch (e) {
-      // If decoding fails, use the original
-      decodedParamName = paramName
+    if (isDangerousParam(paramName.trim())) {
+      blockedParams.push(paramName.trim())
+      debug(`Blocked dangerous parameter: ${paramName.trim()}`)
+      continue
     }
 
-    if (isDangerousParam(decodedParamName)) {
-      blockedParams.push(decodedParamName)
-      debug(`Blocked dangerous parameter: ${decodedParamName}`)
-    } else {
-      safeParts.push(part)
-    }
+    safeParts.push(part)
   }
 
   return {
     sanitized: safeParts.join('&'),
     blockedParams
   }
+}
+
+/**
+ * Scan a string for dangerous parameter names by splitting on & and
+ * checking each segment as a potential param=value pair.
+ * @param {string} str - The string to scan
+ * @returns {Array<string>} - Dangerous param names found
+ */
+function findDangerousParamsInString (str) {
+  if (!str) return []
+  const found = []
+  const parts = str.split('&')
+  for (const part of parts) {
+    const eqIndex = part.indexOf('=')
+    const paramName = eqIndex >= 0 ? part.substring(0, eqIndex) : part
+    if (isDangerousParam(paramName.trim())) {
+      found.push(paramName.trim())
+    }
+  }
+  return found
 }
 
 /**
@@ -117,17 +169,21 @@ function sanitizeParamsObject (params) {
   const sanitized = {}
 
   for (const [key, value] of Object.entries(params)) {
-    // Decode the key to catch encoded attacks
-    let decodedKey
-    try {
-      decodedKey = decodeURIComponent(key)
-    } catch (e) {
-      decodedKey = key
-    }
+    const decodedKey = fullyDecode(key)
 
     if (isDangerousParam(decodedKey)) {
       blockedParams.push(decodedKey)
       debug(`Blocked dangerous parameter: ${decodedKey}`)
+    } else if (typeof value === 'string') {
+      // Check if the value contains smuggled dangerous params
+      const decodedValue = fullyDecode(value)
+      const smuggled = findDangerousParamsInString(decodedValue)
+      if (smuggled.length > 0) {
+        blockedParams.push(...smuggled)
+        debug(`Blocked smuggled params in value of ${decodedKey}: ${smuggled.join(', ')}`)
+      } else {
+        sanitized[key] = value
+      }
     } else {
       sanitized[key] = value
     }
@@ -171,10 +227,11 @@ module.exports = function SolrQuerySanitizer (req, res, next) {
     allBlockedParams = allBlockedParams.concat(result.blockedParams)
   }
 
-  // Log security events
+  // Hard reject if dangerous params were detected
   if (allBlockedParams.length > 0) {
     const uniqueBlocked = [...new Set(allBlockedParams)]
     console.log(`[SECURITY] Blocked dangerous Solr params: ${uniqueBlocked.join(', ')} from ${req.ip || req.connection.remoteAddress}`)
+    return res.status(400).json({ error: 'Request contains prohibited query parameters' })
   }
 
   next()

--- a/tests/test-security/security-solr-ssrf.spec.js
+++ b/tests/test-security/security-solr-ssrf.spec.js
@@ -105,27 +105,61 @@ describe('SolrQuerySanitizer Unit Tests', function () {
   })
 
   describe('sanitizeQueryString', function () {
-    it('should remove shards parameter from query string', function () {
+    it('should reject query containing shards parameter', function () {
       const result = sanitizeQueryString('q=*:*&rows=10&shards=http://internal:8983/solr/admin')
-      assert.equal(result.sanitized, 'q=*:*&rows=10')
+      assert.equal(result.sanitized, '')
       assert.include(result.blockedParams, 'shards')
     })
 
-    it('should remove multiple dangerous parameters', function () {
+    it('should reject query containing multiple dangerous parameters', function () {
       const result = sanitizeQueryString('q=*:*&shards=evil&stream.url=http://evil&debug=true')
-      assert.equal(result.sanitized, 'q=*:*')
-      assert.equal(result.blockedParams.length, 3)
+      assert.equal(result.sanitized, '')
+      assert.isAbove(result.blockedParams.length, 0)
     })
 
-    it('should handle URL-encoded parameter names', function () {
+    it('should catch URL-encoded parameter names', function () {
       const result = sanitizeQueryString('q=*:*&%73hards=evil') // %73 = 's'
       assert.include(result.blockedParams, 'shards')
-      assert.equal(result.sanitized, 'q=*:*')
+      assert.equal(result.sanitized, '')
+    })
+
+    it('should catch double-encoded shards parameter', function () {
+      // %2526 -> %26 after one decode -> & after second decode
+      const result = sanitizeQueryString('q=*:*%2526shards=evil.com')
+      assert.include(result.blockedParams, 'shards')
+      assert.equal(result.sanitized, '')
+    })
+
+    it('should catch triple-encoded shards parameter', function () {
+      // %252526 -> %2526 -> %26 -> &
+      const result = sanitizeQueryString('q=*:*%252526shards=evil.com')
+      assert.include(result.blockedParams, 'shards')
+      assert.equal(result.sanitized, '')
+    })
+
+    it('should catch shards smuggled in value via encoded ampersand', function () {
+      // After full decode: q=*:*&shards=evil
+      const result = sanitizeQueryString('q=*:*%26shards=evil')
+      assert.include(result.blockedParams, 'shards')
+      assert.equal(result.sanitized, '')
+    })
+
+    it('should catch stream.url smuggled via encoding', function () {
+      const result = sanitizeQueryString('q=*:*%26stream.url=http://169.254.169.254/')
+      assert.include(result.blockedParams, 'stream.url')
+      assert.equal(result.sanitized, '')
     })
 
     it('should return original if no dangerous params', function () {
       const result = sanitizeQueryString('q=*:*&rows=10&fq=public:true')
       assert.equal(result.sanitized, 'q=*:*&rows=10&fq=public:true')
+      assert.equal(result.blockedParams.length, 0)
+    })
+
+    it('should not false-positive on values containing dangerous words', function () {
+      // "debug" is in the value, not as a parameter name
+      const result = sanitizeQueryString('q=gene_name:debug_protein&rows=10')
+      assert.equal(result.sanitized, 'q=gene_name:debug_protein&rows=10')
       assert.equal(result.blockedParams.length, 0)
     })
 
@@ -184,7 +218,7 @@ describe('SSRF Integration Tests', function () {
   }
 
   // TIKI-W094-6: Arbitrary Solr Queries lead to Full read SSRF
-  it('should block shards parameter in POST with solrquery content-type', async function () {
+  it('should reject shards parameter in POST with solrquery content-type', async function () {
     const response = await httpRequest({
       ...baseOptions,
       method: 'POST',
@@ -194,11 +228,11 @@ describe('SSRF Integration Tests', function () {
       }
     }, 'q=*:*&rows=1&shards=http://internal:8983/solr/admin')
 
-    // The request should not cause a 500 error (shards should be stripped)
-    assert.notEqual(response.status, 500)
+    assert.equal(response.status, 400)
+    assert.include(response.body, 'prohibited query parameters')
   })
 
-  it('should block shards parameter in GET request', async function () {
+  it('should reject shards parameter in GET request', async function () {
     const response = await httpRequest({
       ...baseOptions,
       method: 'GET',
@@ -208,11 +242,39 @@ describe('SSRF Integration Tests', function () {
       }
     })
 
-    assert.notEqual(response.status, 500)
+    assert.equal(response.status, 400)
+  })
+
+  it('should reject double-encoded shards via solr= POST param', async function () {
+    // This is the exact Synack attack vector: %2526 -> %26 after decodeURIComponent -> & after fullyDecode
+    const response = await httpRequest({
+      ...baseOptions,
+      method: 'POST',
+      path: '/genome/',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded'
+      }
+    }, 'solr=q%3D*:*%2526shards%3Dhttp://evil.com:8983/solr/')
+
+    assert.equal(response.status, 400)
+    assert.include(response.body, 'prohibited query parameters')
+  })
+
+  it('should reject triple-encoded shards parameter', async function () {
+    const response = await httpRequest({
+      ...baseOptions,
+      method: 'POST',
+      path: '/genome/',
+      headers: {
+        'Content-Type': 'application/solrquery+x-www-form-urlencoded'
+      }
+    }, 'q=*:*%252526shards=http://evil.com')
+
+    assert.equal(response.status, 400)
   })
 
   // TIKI-W094-8: SSRF via stream.url
-  it('should block stream.url parameter', async function () {
+  it('should reject stream.url parameter', async function () {
     const response = await httpRequest({
       ...baseOptions,
       method: 'POST',
@@ -222,10 +284,10 @@ describe('SSRF Integration Tests', function () {
       }
     }, 'q=*:*&stream.url=http://169.254.169.254/latest/meta-data/')
 
-    assert.notEqual(response.status, 500)
+    assert.equal(response.status, 400)
   })
 
-  it('should block stream.file parameter', async function () {
+  it('should reject stream.file parameter', async function () {
     const response = await httpRequest({
       ...baseOptions,
       method: 'POST',
@@ -235,11 +297,11 @@ describe('SSRF Integration Tests', function () {
       }
     }, 'q=*:*&stream.file=/etc/passwd')
 
-    assert.notEqual(response.status, 500)
+    assert.equal(response.status, 400)
   })
 
   // TIKI-W094-9: qt parameter for handler override
-  it('should block qt parameter for handler override', async function () {
+  it('should reject qt parameter for handler override', async function () {
     const response = await httpRequest({
       ...baseOptions,
       method: 'POST',
@@ -249,10 +311,10 @@ describe('SSRF Integration Tests', function () {
       }
     }, 'q=*:*&qt=/admin/cores')
 
-    assert.notEqual(response.status, 500)
+    assert.equal(response.status, 400)
   })
 
-  it('should block debug parameters', async function () {
+  it('should reject debug parameters', async function () {
     const response = await httpRequest({
       ...baseOptions,
       method: 'POST',
@@ -262,7 +324,7 @@ describe('SSRF Integration Tests', function () {
       }
     }, 'q=*:*&debug=all&debugQuery=true&echoParams=all')
 
-    assert.notEqual(response.status, 500)
+    assert.equal(response.status, 400)
   })
 
   it('should allow legitimate queries', async function () {
@@ -272,8 +334,8 @@ describe('SSRF Integration Tests', function () {
       path: '/genome/?q=*:*&rows=1&sort=genome_id+asc'
     })
 
-    // Should work normally (may require auth, but shouldn't be a 500)
-    assert.include([200, 400, 401], response.status)
+    // Should work normally (may require auth, but shouldn't be a 400 or 500)
+    assert.include([200, 401], response.status)
   })
 })
 
@@ -419,9 +481,10 @@ describe('Security Headers in Error Responses', function () {
       }
     }, 'q=*:*&shards=http://169.254.169.254/latest/meta-data/')
 
+    assert.equal(response.status, 400)
     // The response should not contain the malicious URL
-    if (response.body) {
-      assert.notInclude(response.body, '169.254.169.254')
-    }
+    assert.notInclude(response.body, '169.254.169.254')
+    // Should contain generic error message
+    assert.include(response.body, 'prohibited query parameters')
   })
 })


### PR DESCRIPTION
## Summary

- Fixes TIKI-W094-6: Arbitrary Solr Queries lead to Full read SSRF (patch failed verification 3 times)
- Root cause: `SolrQuerySanitizer` split on literal `&` only — double-encoded `%2526` survived the split, and Solr decoded it into `&shards=`, enabling SSRF
- Added `fullyDecode()` that recursively applies `decodeURIComponent` until stable, catching all encoding depths
- Scans the fully-decoded query string for dangerous params; rejects the **entire query** if any are found (no more silent stripping)
- Middleware now returns hard `400 { error: "Request contains prohibited query parameters" }` instead of stripping and continuing
- Updated `sanitizeParamsObject()` to also scan values for smuggled params
- Added unit tests for double-encoded, triple-encoded, and value-smuggled attack vectors

## Test plan

- [x] Unit tests pass: `npx mocha tests/test-security/security-solr-ssrf.spec.js --grep "Unit Tests"` (21 passing)
- [ ] Integration tests with running server
- [ ] Verify legitimate queries still work (no false positives on field values containing dangerous words like "debug")
- [ ] Verify double-encoded `solr=` POST param attack returns 400
- [ ] Verify triple-encoded attack returns 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)