### PR TITLE
Retry transient indexing failures instead of dropping them

### DIFF
--- a/bin/p3-index-worker
+++ b/bin/p3-index-worker
@@ -18,6 +18,15 @@ const Http = require('http')
 const solrAgentConfig = Config.get('solr').shortLiveAgent
 const solrAgent = new Http.Agent(solrAgentConfig)
 
+const indexRetry = require('../lib/indexRetry')
+
+// Accumulates transient failures; flushed as a summary email whenever the queue drains.
+const transientFailures = []
+// Rollbacks (cur/ -> new/) deferred until the queue drains, so retried messages
+// reappear on the next pass rather than being re-popped in a tight loop.
+const deferredRollbacks = []
+const MAX_ATTEMPTS = indexRetry.maxAttempts()
+
 // console.log(`Queue Directory: ${queueDirectory}`)
 
 const queue = new Queue(queueDirectory, function (err) {
@@ -71,14 +80,22 @@ function postDocs (filePath, type) {
     path: `/solr/${type}/update?wt=json&overwrite=true&commit=false`
   }, readStream).then((msg_str) => {
     // console.log(`Posted ${type}`)
-    const msg = JSON.parse(msg_str)
+    // Any failure reaching Solr is transient (network reset, non-2xx, an HTML
+    // error page from HAProxy/Solr instead of JSON, or a Solr-reported error) —
+    // tag it so the worker retries rather than permanently failing the job.
+    let msg
+    try {
+      msg = JSON.parse(msg_str)
+    } catch (parseErr) {
+      throw indexRetry.markTransient(new Error(`Non-JSON response from Solr [${type}]: ${parseErr.message}`))
+    }
     if (msg && msg.responseHeader && msg.responseHeader.status === 0) {
       // success
     } else {
-      throw new Error(msg.error.msg)
+      throw indexRetry.markTransient(new Error((msg && msg.error && msg.error.msg) || `Solr error posting to ${type}`))
     }
   }).catch((err) => {
-    throw err
+    throw indexRetry.markTransient(err)
   })
 }
 
@@ -93,6 +110,20 @@ function processQueue (queue) {
       if (!completedHardCommit) {
         console.log('Queue is Empty')
         completedHardCommit = true
+        // Queue just drained — return retried messages to the queue for the next
+        // pass, then flush a summary email for any transient failures accumulated
+        // this pass, resetting both accumulators.
+        const rbs = deferredRollbacks.splice(0)
+        indexRetry.runDeferredRollbacks(rbs, (m) => console.error(m)).then(() => {
+          if (transientFailures.length > 0) {
+            const batch = transientFailures.splice(0)
+            return indexRetry.sendRunSummary(batch).then((info) => {
+              if (info) { console.log(`Sent transient-failure summary email (${batch.length} failure(s))`) }
+            })
+          }
+        }).catch((mailErr) => {
+          console.error(`${(new Date()).toISOString()}: Failed to send summary email: ${mailErr}`)
+        })
         setTimeout(() => {
           processQueue(queue)
         }, 180000)
@@ -119,13 +150,32 @@ function processQueue (queue) {
           return
         }
 
+        let genomeId
+        // Resolve the queue transaction (commit/rollback) exactly once, update
+        // history, then resume. `outcome` is { ok:true } or { ok:false, err }.
+        let finished = false
+        const finish = (outcome) => {
+          if (finished) { return }
+          finished = true
+          indexRetry.finishMessage({
+            queueDirectory, id: message.id, genomeId, commit, rollback,
+            outcome, maxAttempts: MAX_ATTEMPTS, transientFailures, deferredRollbacks,
+            log: (m) => console.error(m)
+          }).then(() => {
+            processQueue(queue)
+          }, (histErr) => {
+            console.error(`${(new Date()).toISOString()}: Error in updating history: ${histErr} while processing ${message.id}`)
+            processQueue(queue)
+          })
+        }
+
         try {
           console.log(`\nStart indexing ${message.id} User: ${message.user}`)
 
           const fileDefs = []
           const beforeProcess = (new Date()).getTime()
 
-          const genomeId = fs.readJsonSync(message.files.genome.path)[0]['genome_id']
+          genomeId = fs.readJsonSync(message.files.genome.path)[0]['genome_id']
 
           Object.keys(message.files).forEach(core => {
             let files = message.files[core]
@@ -162,36 +212,14 @@ function processQueue (queue) {
           Promise.all(fileDefs).then(() => {
             const afterProcess = (new Date()).getTime()
             console.log(`  ${(afterProcess - beforeProcess)}ms elapsed for genome (${genomeId})`)
-
-            updateHistory(message.id, 'submitted', genomeId).then(() => {
-              // commit()
-              processQueue(queue)
-            }, (err) => {
-              console.error(`${(new Date()).toISOString()}: Error in updating history: ${err} while processing ${message.id}`)
-            })
+            finish({ ok: true })
           }, (err) => {
             console.error(`${(new Date()).toISOString()}: Error in fullfilling fileDefs: ${err} while processing ${message.id}`)
-
-            // trigger rollback
-            // this operation is very costly. Delete by ID is preferred.
-            // IndexingCores.forEach(core => {
-            //   deleteDocs(core, genomeId)
-            // })
-
-            updateHistory(message.id, 'error', err.message).then(() => {
-              // commit()
-              processQueue(queue) // Resume
-            }, (err) => {
-              console.error(`${(new Date()).toISOString()}: Error in updating history: ${err} while processing ${message.id}`)
-            })
+            finish({ ok: false, err })
           })
         } catch (err) {
-          updateHistory(message.id, 'error', err.message).then(() => {
-            // commit()
-            processQueue(queue) // Resume
-          }, (err) => {
-            console.error(`${(new Date()).toISOString()}: Error in updating history: ${err} while processing ${message.id}`)
-          })
+          // Synchronous failure (e.g. malformed genome input file) — permanent.
+          finish({ ok: false, err })
         }
       })
     }
@@ -260,43 +288,5 @@ function updateJSONStreamWithAccessControl (fileName, filePath, core, owner) {
     }
   })
 }
-
-function updateHistory (id, state, msg) {
-  return new Promise((resolve, reject) => {
-    const historyPath = Path.join(queueDirectory, 'history', id)
-
-    console.log(`Updating History ${historyPath}`)
-
-    fs.readJson(historyPath, (err, data) => {
-      if (err) {
-        reject(err)
-        return
-      }
-
-      switch (state) {
-        case 'submitted':
-          data.state = state
-          data.genomeId = msg
-          data.submissionTime = new Date()
-          break
-        case 'error':
-          data.state = state
-          data.error = msg
-          break
-        default:
-          data.state = state
-          break
-      }
-
-      fs.writeJson(historyPath, data, (err) => {
-        if (err) {
-          console.log(`Error writing to history: ${id}`)
-          reject(err)
-          return
-        }
-
-        resolve(true)
-      })
-    })
-  })
-}
+// History updates and queue commit/rollback are now handled by
+// lib/indexRetry.finishMessage (see processQueue above).

--- a/bin/p3-index-worker-once
+++ b/bin/p3-index-worker-once
@@ -17,8 +17,16 @@ const streamRequest = (parsedSolrUrl.protocol == "https:") ? httpsStreamRequest 
 console.log(streamRequest);
 
 const Web = require('../web');
+const indexRetry = require('../lib/indexRetry')
 
 var solrAgent = Web.getSolrAgent();
+
+// Accumulates transient failures across this run for the end-of-run summary email.
+const transientFailures = []
+// Rollbacks (cur/ -> new/) deferred until the queue drains, so retried messages
+// reappear on the NEXT run rather than being re-popped in a tight loop this run.
+const deferredRollbacks = []
+const MAX_ATTEMPTS = indexRetry.maxAttempts()
 
 // console.log(`Queue Directory: ${queueDirectory}`)
 
@@ -62,14 +70,23 @@ function postDocs (filePath, type) {
     path: `/solr/${type}/update?wt=json&overwrite=true&commit=false`
   }, readStream).then((msg_str) => {
     // console.log(`Posted ${type}`)
-    const msg = JSON.parse(msg_str)
+    // Any failure reaching Solr is transient (network reset, non-2xx, an HTML
+    // error page from HAProxy/Solr instead of JSON, or a Solr-reported error) —
+    // tag it so the worker retries rather than permanently failing the job.
+    let msg
+    try {
+      msg = JSON.parse(msg_str)
+    } catch (parseErr) {
+      // e.g. "<html><body>...502 Bad Gateway...</body></html>"
+      throw indexRetry.markTransient(new Error(`Non-JSON response from Solr [${type}]: ${parseErr.message}`))
+    }
     if (msg && msg.responseHeader && msg.responseHeader.status === 0) {
       // success
     } else {
-      throw new Error(msg.error.msg)
+      throw indexRetry.markTransient(new Error((msg && msg.error && msg.error.msg) || `Solr error posting to ${type}`))
     }
   }).catch((err) => {
-    throw err
+    throw indexRetry.markTransient(err)
   })
 }
 
@@ -81,7 +98,19 @@ function processQueue (queue) {
     }
 
     if (length < 1) {
-	process.exit(0);
+      // End of run: return retried messages to the queue for the next run, then
+      // send one summary email if any transient failures occurred, then exit.
+      // Send in the callback so the process doesn't exit before the mail is
+      // flushed. Exit 0 regardless (cron logs hard failures separately).
+      indexRetry.runDeferredRollbacks(deferredRollbacks, (m) => console.error(m)).then(() => {
+        return indexRetry.sendRunSummary(transientFailures)
+      }).then((info) => {
+        if (info) { console.log(`Sent transient-failure summary email (${transientFailures.length} failure(s))`) }
+        process.exit(0)
+      }, (mailErr) => {
+        console.error(`${(new Date()).toISOString()}: Failed to send summary email: ${mailErr}`)
+        process.exit(0)
+      })
     } else {
       completedHardCommit = false
       console.log(`Start processing queued items: ${length}`)
@@ -100,13 +129,32 @@ function processQueue (queue) {
           return
         }
 
+        let genomeId
+        // Resolve the queue transaction (commit/rollback) exactly once, update
+        // history, then resume. `outcome` is { ok:true } or { ok:false, err }.
+        let finished = false
+        const finish = (outcome) => {
+          if (finished) { return }
+          finished = true
+          indexRetry.finishMessage({
+            queueDirectory, id: message.id, genomeId, commit, rollback,
+            outcome, maxAttempts: MAX_ATTEMPTS, transientFailures, deferredRollbacks,
+            log: (m) => console.error(m)
+          }).then(() => {
+            processQueue(queue)
+          }, (histErr) => {
+            console.error(`${(new Date()).toISOString()}: Error in updating history: ${histErr} while processing ${message.id}`)
+            processQueue(queue)
+          })
+        }
+
         try {
           console.log(`\nStart indexing ${message.id} User: ${message.user}`)
 
           const fileDefs = []
           const beforeProcess = (new Date()).getTime()
 
-          const genomeId = fs.readJsonSync(message.files.genome.path)[0]['genome_id']
+          genomeId = fs.readJsonSync(message.files.genome.path)[0]['genome_id']
 
           Object.keys(message.files).forEach(core => {
             let files = message.files[core]
@@ -143,42 +191,14 @@ function processQueue (queue) {
           Promise.all(fileDefs).then(() => {
             const afterProcess = (new Date()).getTime()
             console.log(`  ${(afterProcess - beforeProcess)}ms elapsed for genome (${genomeId})`)
-
-            updateHistory(message.id, 'submitted', genomeId).then(() => {
-              // commit()
-		  //console.log("Ending now 3");
-		  //process.exit(0);
-              processQueue(queue)
-            }, (err) => {
-              console.error(`${(new Date()).toISOString()}: Error in updating history: ${err} while processing ${message.id}`)
-            })
+            finish({ ok: true })
           }, (err) => {
             console.error(`${(new Date()).toISOString()}: Error in fullfilling fileDefs: ${err} while processing ${message.id}`)
-
-            // trigger rollback
-            // this operation is very costly. Delete by ID is preferred.
-            // IndexingCores.forEach(core => {
-            //   deleteDocs(core, genomeId)
-            // })
-
-            updateHistory(message.id, 'error', err.message).then(() => {
-              // commit()
-		  //console.log("Ending now 2");
-		  //process.exit(0);
-              processQueue(queue) // Resume
-            }, (err) => {
-              console.error(`${(new Date()).toISOString()}: Error in updating history: ${err} while processing ${message.id}`)
-            })
+            finish({ ok: false, err })
           })
         } catch (err) {
-          updateHistory(message.id, 'error', err.message).then(() => {
-            // commit()
-		  //console.log("Ending now");
-		  //process.exit(0);
-            processQueue(queue) // Resume
-          }, (err) => {
-            console.error(`${(new Date()).toISOString()}: Error in updating history: ${err} while processing ${message.id}`)
-          })
+          // Synchronous failure (e.g. malformed genome input file) — permanent.
+          finish({ ok: false, err })
         }
       })
     }
@@ -247,43 +267,5 @@ function updateJSONStreamWithAccessControl (fileName, filePath, core, owner) {
     }
   })
 }
-
-function updateHistory (id, state, msg) {
-  return new Promise((resolve, reject) => {
-    const historyPath = Path.join(queueDirectory, 'history', id)
-
-    console.log(`Updating History ${historyPath}`)
-
-    fs.readJson(historyPath, (err, data) => {
-      if (err) {
-        reject(err)
-        return
-      }
-
-      switch (state) {
-        case 'submitted':
-          data.state = state
-          data.genomeId = msg
-          data.submissionTime = new Date()
-          break
-        case 'error':
-          data.state = state
-          data.error = msg
-          break
-        default:
-          data.state = state
-          break
-      }
-
-      fs.writeJson(historyPath, data, (err) => {
-        if (err) {
-          console.log(`Error writing to history: ${id}`)
-          reject(err)
-          return
-        }
-
-        resolve(true)
-      })
-    })
-  })
-}
+// History updates and queue commit/rollback are now handled by
+// lib/indexRetry.finishMessage (see processQueue above).

--- a/bin/p3-requeue-errors
+++ b/bin/p3-requeue-errors
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+
+// Recover index jobs stranded in 'error' state from before the retry fix.
+//
+// Background: popping a queue message renames its file new/ -> cur/. The old
+// worker never called commit()/rollback(), so errored (and even successful)
+// messages were left in cur/ forever and never reprocessed. This script finds
+// history entries in 'error' state, locates their queue message still sitting in
+// cur/, and renames it back to new/ so the next worker run picks it up. It also
+// resets the history entry (state 'queued', attempts 0, clears error fields).
+//
+// Usage:
+//   bin/p3-requeue-errors --dry-run     # list what would be requeued
+//   bin/p3-requeue-errors --confirm     # actually requeue
+//   bin/p3-requeue-errors --confirm --state error,retrying   # also retryings
+
+const Config = require('../config')
+const opts = require('commander')
+const Path = require('path')
+const fs = require('fs-extra')
+
+const queueDir = Config.get('queueDirectory')
+const historyDir = Path.join(queueDir, 'history')
+const newDir = Path.join(queueDir, 'new')
+const curDir = Path.join(queueDir, 'cur')
+
+if (require.main === module) {
+  opts.option('-n, --dry-run', 'List what would be requeued without changing anything')
+    .option('-c, --confirm', 'Perform the requeue')
+    .option('-s, --state <values>', 'Comma-separated history states to requeue (default: error)', 'error')
+    .parse(process.argv)
+
+  if (!opts.dryRun && !opts.confirm) {
+    console.error('Specify --dry-run to preview, or --confirm to requeue.')
+    opts.help()
+  }
+
+  const states = opts.state.split(',').map((s) => s.trim()).filter(Boolean)
+  requeue(states, !!opts.confirm)
+}
+
+function requeue (states, confirm) {
+  // 1. Collect target ids from history.
+  const targetIds = new Map() // id -> history data
+  fs.readdirSync(historyDir).forEach((name) => {
+    let data
+    try {
+      data = fs.readJsonSync(Path.join(historyDir, name))
+    } catch (e) {
+      return // corrupt / unreadable history file — skip
+    }
+    if (data && states.includes(data.state)) {
+      targetIds.set(data.id || name, data)
+    }
+  })
+
+  if (targetIds.size === 0) {
+    console.log(`No history entries in state(s): ${states.join(', ')}`)
+    return
+  }
+  console.log(`Found ${targetIds.size} history ent(y|ies) in state(s): ${states.join(', ')}`)
+
+  // 2. Map queue message files in cur/ to their job id (the file content is the
+  //    JSON message pushed by the indexer route, whose .id is the qid).
+  const curFiles = fs.existsSync(curDir) ? fs.readdirSync(curDir) : []
+  const idToCurFile = new Map()
+  curFiles.forEach((fname) => {
+    try {
+      const msg = fs.readJsonSync(Path.join(curDir, fname))
+      if (msg && msg.id) { idToCurFile.set(msg.id, fname) }
+    } catch (e) {
+      // not JSON / partial — ignore
+    }
+  })
+
+  let moved = 0
+  const orphans = []
+
+  targetIds.forEach((data, id) => {
+    const fname = idToCurFile.get(id)
+    if (!fname) {
+      orphans.push(id)
+      return
+    }
+
+    const from = Path.join(curDir, fname)
+    const to = Path.join(newDir, fname)
+
+    if (!confirm) {
+      console.log(`[dry-run] would requeue ${id} (genome=${data.genomeId || '?'}) : cur/${fname} -> new/${fname}`)
+      moved++
+      return
+    }
+
+    // cur/ and new/ are in the same maildir (same filesystem), so a rename is
+    // atomic and correct — this is exactly how file-queue's rollback moves them.
+    if (fs.existsSync(to)) {
+      console.error(`Target new/${fname} already exists; skipping ${id}`)
+      return
+    }
+    try {
+      fs.renameSync(from, to)
+    } catch (e) {
+      console.error(`Failed to move cur/${fname} -> new/: ${e.message}`)
+      return
+    }
+
+    // Reset history so the next run treats it as fresh.
+    try {
+      const hpath = Path.join(historyDir, id)
+      const hdata = fs.readJsonSync(hpath)
+      hdata.state = 'queued'
+      hdata.attempts = 0
+      delete hdata.error
+      delete hdata.lastError
+      delete hdata.lastAttemptTime
+      hdata.requeueTime = new Date()
+      fs.writeJsonSync(hpath, hdata)
+    } catch (e) {
+      console.error(`Requeued cur/${fname} but failed to reset history ${id}: ${e.message}`)
+    }
+
+    console.log(`Requeued ${id} (genome=${data.genomeId || '?'})`)
+    moved++
+  })
+
+  console.log('')
+  console.log(`${confirm ? 'Requeued' : 'Would requeue'}: ${moved}`)
+  if (orphans.length) {
+    console.log(`No queue message found in cur/ for ${orphans.length} error job(s) — their queue file was lost and they must be re-submitted manually:`)
+    orphans.forEach((id) => console.log(`  ${id}`))
+  }
+}

--- a/config.js
+++ b/config.js
@@ -86,6 +86,19 @@ const defaults = {
     pass: ''
   },
 
+  // Outbound email (nodemailer). Production SMTP host/username/password live in
+  // p3api.conf; these are safe local defaults. localSendmail:true uses the local
+  // MTA instead of an SMTP relay. indexAlertTo/indexMaxAttempts drive the index
+  // worker's transient-error retry alerting (see bin/p3-index-worker-once).
+  email: {
+    localSendmail: false,
+    defaultFrom: 'BV-BRC <do-not-reply@bv-brc.org>',
+    host: 'localhost',
+    port: 25,
+    indexAlertTo: 'bvbrc-admin@lists.cels.anl.gov',
+    indexMaxAttempts: 30
+  },
+
   collectionUniqueKeys: {
     antibiotics: 'pubchem_cid',
     bioset: 'bioset_id',

--- a/lib/indexRetry.js
+++ b/lib/indexRetry.js
@@ -1,0 +1,187 @@
+'use strict'
+
+// Shared retry / commit-rollback / history-update logic for the index workers
+// (bin/p3-index-worker-once and bin/p3-index-worker). Keeping it here means both
+// workers classify errors and drive the maildir queue transaction identically.
+//
+// Queue semantics (file-queue maildir): popping a message renames its file
+// new/ -> cur/ and hands back commit(cb) [unlink from cur/] and rollback(cb)
+// [rename cur/ -> new/]. queue.length() counts only new/. So:
+//   - commit()   => message is done, removed from the queue.
+//   - rollback() => message returns to the queue for the next worker run.
+// Historically both were commented out, which stranded every popped message in
+// cur/ forever: errored jobs never retried and successful jobs leaked.
+
+const Path = require('path')
+const fs = require('fs-extra')
+const Config = require('../config')
+const mailer = require('./mailer')
+
+const STATE_SUBMITTED = 'submitted'
+const STATE_RETRYING = 'retrying'
+const STATE_ERROR = 'error'
+
+// Tag an error as transient (worth retrying). Applied at the source — anything
+// exiting the Solr POST path. Default is permanent, so an unclassified error is
+// never retried (safer than burning 30 attempts on a genuinely-bad job).
+function markTransient (err) {
+  if (err && typeof err === 'object') { err.transient = true }
+  return err
+}
+
+function isTransient (err) {
+  return !!(err && typeof err === 'object' && err.transient)
+}
+
+function errMessage (err) {
+  if (err && err.message) { return err.message }
+  return String(err)
+}
+
+function readAttempts (queueDirectory, id) {
+  try {
+    const data = fs.readJsonSync(Path.join(queueDirectory, 'history', id))
+    return (data && typeof data.attempts === 'number') ? data.attempts : 0
+  } catch (e) {
+    return 0
+  }
+}
+
+// Merge-patch a history file. Preserves fields not named in `patch`.
+function patchHistory (queueDirectory, id, patch) {
+  return new Promise((resolve, reject) => {
+    const historyPath = Path.join(queueDirectory, 'history', id)
+    fs.readJson(historyPath, (err, data) => {
+      if (err) { reject(err); return }
+      Object.assign(data, patch)
+      fs.writeJson(historyPath, data, (werr) => {
+        if (werr) { reject(werr); return }
+        resolve(data)
+      })
+    })
+  })
+}
+
+// maildir commit/rollback take a node-style callback. Wrap as promises; log but
+// don't fail the chain if the fs op errors (history is already updated).
+function runTxn (fn, label, log) {
+  return new Promise((resolve) => {
+    if (typeof fn !== 'function') { resolve(); return }
+    fn((err) => {
+      if (err && log) { log(`${(new Date()).toISOString()}: queue ${label} failed: ${err}`) }
+      resolve()
+    })
+  })
+}
+
+/**
+ * Resolve one popped message: update history, then commit or rollback the queue
+ * transaction according to the outcome.
+ *
+ * @param {object} o
+ * @param {string} o.queueDirectory
+ * @param {string} o.id            history/queue id
+ * @param {string} o.genomeId
+ * @param {function} o.commit       maildir commit(cb)
+ * @param {function} o.rollback     maildir rollback(cb)
+ * @param {object}  o.outcome       { ok:true } | { ok:false, err }
+ * @param {number}  o.maxAttempts
+ * @param {Array}   o.transientFailures  accumulator for the run-summary email
+ * @param {Array}   o.deferredRollbacks  accumulator of rollback fns to run at drain
+ * @param {function} [o.log]
+ * @returns {Promise}
+ *
+ * IMPORTANT: on a transient retry we do NOT roll back inline. rollback renames
+ * the message cur/ -> new/, and processQueue immediately re-reads new/ and would
+ * re-pop the same message, burning all attempts in a single run. Instead we leave
+ * the file in cur/ (uncounted by queue.length) and register the rollback to run
+ * once the queue has drained, so the retry lands on the NEXT worker run.
+ */
+function finishMessage (o) {
+  const { queueDirectory, id, genomeId, commit, rollback, outcome, maxAttempts, transientFailures, deferredRollbacks, log } = o
+  const doCommit = () => runTxn(commit, 'commit', log)
+
+  if (outcome.ok) {
+    return patchHistory(queueDirectory, id, {
+      state: STATE_SUBMITTED, genomeId, submissionTime: new Date()
+    }).then(doCommit)
+  }
+
+  const err = outcome.err
+  const msg = errMessage(err)
+
+  if (isTransient(err)) {
+    const attempts = readAttempts(queueDirectory, id) + 1
+    if (attempts < maxAttempts) {
+      // Retry next run: leave the file in cur/, defer the rollback to drain time.
+      transientFailures.push({ id, genomeId, attempts, error: msg, giveUp: false })
+      if (deferredRollbacks && rollback) { deferredRollbacks.push(rollback) }
+      return patchHistory(queueDirectory, id, {
+        state: STATE_RETRYING, attempts, lastError: msg, lastAttemptTime: new Date()
+      })
+    }
+    // Exhausted retries — give up, drop from queue.
+    transientFailures.push({ id, genomeId, attempts, error: msg, giveUp: true })
+    return patchHistory(queueDirectory, id, {
+      state: STATE_ERROR, attempts, error: msg
+    }).then(doCommit)
+  }
+
+  // Permanent failure — drop from queue, no retry.
+  return patchHistory(queueDirectory, id, {
+    state: STATE_ERROR, error: msg
+  }).then(doCommit)
+}
+
+// Run all deferred rollbacks (cur/ -> new/) sequentially. Call once the queue
+// has drained so retried messages reappear on the next run, not this one.
+function runDeferredRollbacks (deferredRollbacks, log) {
+  let p = Promise.resolve()
+  ;(deferredRollbacks || []).forEach((rb) => {
+    p = p.then(() => runTxn(rb, 'rollback', log))
+  })
+  return p
+}
+
+// Send one summary email if any transient failures occurred this run. Resolves
+// to null (no send) when there were none or no recipient is configured.
+function sendRunSummary (transientFailures) {
+  if (!transientFailures || transientFailures.length === 0) { return Promise.resolve(null) }
+
+  const mailconf = Config.get('email') || {}
+  const to = mailconf.indexAlertTo
+  if (!to) { return Promise.resolve(null) }
+
+  const retrying = transientFailures.filter((f) => !f.giveUp)
+  const gaveUp = transientFailures.filter((f) => f.giveUp)
+
+  const lines = []
+  lines.push(`The BV-BRC genome index worker hit ${transientFailures.length} transient failure(s) this run.`)
+  lines.push('')
+  if (retrying.length) {
+    lines.push(`Will retry next run (${retrying.length}):`)
+    retrying.forEach((f) => lines.push(`  ${f.id}  genome=${f.genomeId}  attempt ${f.attempts}  ${f.error}`))
+    lines.push('')
+  }
+  if (gaveUp.length) {
+    lines.push(`Gave up after reaching the attempt cap (${gaveUp.length}) — now in permanent error state:`)
+    gaveUp.forEach((f) => lines.push(`  ${f.id}  genome=${f.genomeId}  attempt ${f.attempts}  ${f.error}`))
+  }
+
+  const subject = `[BV-BRC] index worker: ${transientFailures.length} transient failure(s), ${gaveUp.length} gave up`
+  return mailer.sendReport({ to, subject, text: lines.join('\n') })
+}
+
+function maxAttempts () {
+  const mailconf = Config.get('email') || {}
+  return mailconf.indexMaxAttempts || 30
+}
+
+module.exports = {
+  markTransient,
+  isTransient,
+  finishMessage,
+  runDeferredRollbacks,
+  sendRunSummary,
+  maxAttempts
+}

--- a/lib/mailer.js
+++ b/lib/mailer.js
@@ -1,0 +1,75 @@
+'use strict'
+
+// Config-driven nodemailer wrapper. The transport is built from config.get('email')
+// so production (SMTP relay) and dev (local sendmail / different relay) pick up their
+// own settings from the same config file. See config.js for the defaults block and
+// p3api.conf for the real production SMTP credentials.
+
+const nodemailer = require('nodemailer')
+const Config = require('../config')
+const debug = require('debug')('p3api-server:mailer')
+
+let transport
+
+function getTransport () {
+  if (transport) { return transport }
+
+  const mailconf = Config.get('email') || {}
+
+  if (mailconf.localSendmail) {
+    transport = nodemailer.createTransport({ sendmail: true, newline: 'unix' })
+  } else {
+    const opts = {
+      host: mailconf.host || 'localhost',
+      port: mailconf.port || 25
+    }
+    if (mailconf.username) {
+      opts.auth = { user: mailconf.username, pass: mailconf.password }
+    }
+    opts.tls = { rejectUnauthorized: true }
+    transport = nodemailer.createTransport(opts)
+  }
+
+  return transport
+}
+
+// Strip CR/LF/null to prevent header injection from any interpolated value.
+function sanitizeHeader (val) {
+  return String(val == null ? '' : val).replace(/[\r\n\0]/g, '')
+}
+
+/**
+ * Send a plain-text report email.
+ * @param {object} msg - { to, subject, text, from? }
+ * @returns {Promise} resolves with nodemailer info, rejects on send failure.
+ */
+function sendReport (msg) {
+  return new Promise((resolve, reject) => {
+    const mailconf = Config.get('email') || {}
+    const from = sanitizeHeader(msg.from || mailconf.defaultFrom || 'BV-BRC <do-not-reply@bv-brc.org>')
+    const to = sanitizeHeader(msg.to)
+    const subject = sanitizeHeader(msg.subject).slice(0, 200)
+
+    if (!to) {
+      reject(new Error('sendReport: no recipient (to) given'))
+      return
+    }
+
+    getTransport().sendMail({
+      from: from,
+      to: to,
+      subject: subject,
+      text: String(msg.text == null ? '' : msg.text)
+    }, (err, info) => {
+      if (err) {
+        debug('Mail send failed: %s', err)
+        reject(err)
+        return
+      }
+      debug('Mail sent: %o', info && info.messageId)
+      resolve(info)
+    })
+  })
+}
+
+module.exports = { sendReport, sanitizeHeader }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "p3api",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "p3api",
-      "version": "1.9.2",
+      "version": "1.9.3",
       "dependencies": {
         "apicache": "^1.6.2",
         "archiver": "^4.0.2",
@@ -31,6 +31,7 @@
         "morgan": "^1.9.1",
         "nconf": "^0.10.0",
         "node-xlsx": "^0.24.0",
+        "nodemailer": "^6.10.1",
         "npm": "^11.11.0",
         "p3-user": "git+https://github.com/PATRIC3/p3_user.git#c0fee2a0ac833fa78401266d705f8c5a6b80e4f3",
         "pino": "^6.2.1",
@@ -694,7 +695,8 @@
     "node_modules/addressparser": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/addressparser/-/addressparser-0.3.2.tgz",
-      "integrity": "sha1-WYc/Nej89sc2HBAjkmHXbhU0i7I="
+      "integrity": "sha512-fDlslCJpojuY1cnb7tY7COAriA7cdSzDiWyrWNdFn7Cjd+jrEgZavqkOgD/wg+eH765YPnQjqlS88OL/Q0Qtkg==",
+      "license": "MIT"
     },
     "node_modules/agent-base": {
       "version": "6.0.2",
@@ -1596,8 +1598,9 @@
     "node_modules/buildmail": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/buildmail/-/buildmail-2.0.0.tgz",
-      "integrity": "sha1-8LewpZ6aShtQZrv6BR0kjzgy7s4=",
+      "integrity": "sha512-nzs+TRLUuC+4RUuEdUwjcu3EKXhbO2mTd20xZngRELIeGOlMWZjanEUxdOkVGx4TRN9CWzxqGrrxBYQUrBhCvQ==",
       "deprecated": "This project is unmaintained",
+      "license": "MIT",
       "dependencies": {
         "addressparser": "^0.3.2",
         "libbase64": "^0.1.0",
@@ -1610,6 +1613,7 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -1617,7 +1621,8 @@
     "node_modules/buildmail/node_modules/needle": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/needle/-/needle-0.10.0.tgz",
-      "integrity": "sha1-FqJNY/KmEVLrdMzh0Sr4XFB1d9Q=",
+      "integrity": "sha512-83oJxMoVmAew7kZ51Z4jeWndgXY7/yeSMUh4H9ayEYkfRbu7IGPW45Ft20aXbicU6z7mZU2V41MZHzysdBLoFQ==",
+      "license": "MIT",
       "dependencies": {
         "debug": "^2.1.2",
         "iconv-lite": "^0.4.4"
@@ -1738,6 +1743,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -1751,6 +1757,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -1762,6 +1769,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -3145,6 +3153,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -4893,6 +4902,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -4992,7 +5002,8 @@
     "node_modules/hosted-git-info": {
       "version": "2.8.8",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg=="
+      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+      "dev": true
     },
     "node_modules/hsl-regex": {
       "version": "1.0.0",
@@ -5593,7 +5604,8 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
     },
     "node_modules/isobject": {
       "version": "3.0.1",
@@ -5647,7 +5659,8 @@
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true
     },
     "node_modules/json-patch": {
       "version": "0.6.1",
@@ -5807,12 +5820,14 @@
     "node_modules/libbase64": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/libbase64/-/libbase64-0.1.0.tgz",
-      "integrity": "sha1-YjUag5VjrF/1vSbxL2Dpgwu3UeY="
+      "integrity": "sha512-B91jifmFw1DKEqEWstSpg1PbtUbBzR4yQAPT86kCQXBtud1AJVA+Z6RSklSrqmKe4q2eiEufgnhqJKPgozzfIQ==",
+      "license": "MIT"
     },
     "node_modules/libmime": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/libmime/-/libmime-1.2.0.tgz",
-      "integrity": "sha1-jYS087Ils3BEECNu9JSQZDa6dCs=",
+      "integrity": "sha512-T1b/a+85vR5uJOzvQG2xZlGsWdELj02jijj/ooBcIwJUF11yiE6n2T3EI9n0B5kJX1GhI9BTTb13g/bhnhxDnw==",
+      "license": "MIT",
       "dependencies": {
         "iconv-lite": "^0.4.13",
         "libbase64": "^0.1.0",
@@ -5822,7 +5837,8 @@
     "node_modules/libqp": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/libqp/-/libqp-1.1.0.tgz",
-      "integrity": "sha1-9ebgatdLeU+1tbZpiL9yjvHe2+g="
+      "integrity": "sha512-4Rgfa0hZpG++t1Vi2IiqXG9Ad1ig4QTmtuZF946QJP4bPqOYC78ixUXgz5TW/wE7lNaNKlplSYTxQ+fR2KZ0EA==",
+      "license": "MIT"
     },
     "node_modules/lilconfig": {
       "version": "2.0.3",
@@ -6000,8 +6016,9 @@
     "node_modules/mailcomposer": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mailcomposer/-/mailcomposer-2.1.0.tgz",
-      "integrity": "sha1-plMYIomWFP7omckiJtgeK5y7GD0=",
+      "integrity": "sha512-vwqmIfiM3wiWAplTMfLoPzVvI2+Z+BL9pJQ2DXynIVYRPig5ulGsm+3ytMR88pP7Q2ReMj3wCYaq8m5xgfHzPg==",
       "deprecated": "This project is unmaintained",
+      "license": "MIT",
       "dependencies": {
         "buildmail": "^2.0.0",
         "libmime": "^1.2.0"
@@ -6838,6 +6855,31 @@
         "ncp": "bin/ncp"
       }
     },
+    "node_modules/needle": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-0.11.0.tgz",
+      "integrity": "sha512-76paDodxGl3b+rcg8fYv7fkRLJp0kHprOL+HPtfDkT4QKJALSFJKWrJp7Qw83JVtPThH9Vy7iF4KR4Eq1fVYWA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^2.1.2",
+        "iconv-lite": "^0.4.4"
+      },
+      "bin": {
+        "needle": "bin/needle"
+      },
+      "engines": {
+        "node": ">= 0.10.x"
+      }
+    },
+    "node_modules/needle/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
     "node_modules/negotiator": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
@@ -6936,25 +6978,19 @@
       }
     },
     "node_modules/nodemailer": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-1.11.0.tgz",
-      "integrity": "sha1-TmnLObAwFbHR7wx4qBVBK56Xb3k=",
-      "deprecated": "All versions below 4.0.1 of Nodemailer are deprecated. See https://nodemailer.com/status/",
-      "dependencies": {
-        "libmime": "^1.2.0",
-        "mailcomposer": "^2.1.0",
-        "needle": "^0.11.0",
-        "nodemailer-direct-transport": "^1.1.0",
-        "nodemailer-smtp-transport": "^1.1.0"
-      },
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=6.0.0"
       }
     },
     "node_modules/nodemailer-direct-transport": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/nodemailer-direct-transport/-/nodemailer-direct-transport-1.1.0.tgz",
-      "integrity": "sha1-oveHCO5vFuoFc/yClJ0Tj/Fy9iQ=",
+      "integrity": "sha512-cZ1EfBCkBAeR2+a/uFZ6IXh3YxtUPvBxebZB4zjE/J9LYPGqOPxkhvQMB/L6RA1lrcgyBS/Y1nF7vE69AqE+/Q==",
+      "license": "MIT",
       "dependencies": {
         "smtp-connection": "^1.3.1"
       }
@@ -6972,47 +7008,6 @@
       "version": "0.1.10",
       "resolved": "https://registry.npmjs.org/nodemailer-wellknown/-/nodemailer-wellknown-0.1.10.tgz",
       "integrity": "sha1-WG24EB2zDLRDjrVGc3pBqtDPE9U="
-    },
-    "node_modules/nodemailer/node_modules/clone": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/nodemailer/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/nodemailer/node_modules/needle": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-0.11.0.tgz",
-      "integrity": "sha1-AqcbAI6vfVWuifuf12hbe4jXvCk=",
-      "dependencies": {
-        "debug": "^2.1.2",
-        "iconv-lite": "^0.4.4"
-      },
-      "bin": {
-        "needle": "bin/needle"
-      },
-      "engines": {
-        "node": ">= 0.10.x"
-      }
-    },
-    "node_modules/nodemailer/node_modules/nodemailer-smtp-transport": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/nodemailer-smtp-transport/-/nodemailer-smtp-transport-1.1.0.tgz",
-      "integrity": "sha1-5sN/MYhaswgOfe089SjErX5pE5g=",
-      "dependencies": {
-        "clone": "^1.0.2",
-        "nodemailer-wellknown": "^0.1.7",
-        "smtp-connection": "^1.3.7"
-      }
     },
     "node_modules/nopt": {
       "version": "5.0.0",
@@ -9285,6 +9280,43 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/p3-user/node_modules/nodemailer": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-1.11.0.tgz",
+      "integrity": "sha512-CA+mq08eL85Gg5S/Z4VdkS9f0jZUbiHr4XgUlifo7KGRem16tJuzwHOygW9CxfDzT48WgV8ffbNNJWX0BiT3Ag==",
+      "deprecated": "All versions below 4.0.1 of Nodemailer are deprecated. See https://nodemailer.com/status/",
+      "license": "MIT",
+      "dependencies": {
+        "libmime": "^1.2.0",
+        "mailcomposer": "^2.1.0",
+        "needle": "^0.11.0",
+        "nodemailer-direct-transport": "^1.1.0",
+        "nodemailer-smtp-transport": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/p3-user/node_modules/nodemailer/node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/p3-user/node_modules/nodemailer/node_modules/nodemailer-smtp-transport": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/nodemailer-smtp-transport/-/nodemailer-smtp-transport-1.1.0.tgz",
+      "integrity": "sha512-mFYe1i3c7buIOCs6m8VydDcyk+NW9LuAoyYeGxIqlzfWuX7PMHHIh2PTE90Wvx9+rdgTutPvrKaXMBABNf/m/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^1.0.2",
+        "nodemailer-wellknown": "^0.1.7",
+        "smtp-connection": "^1.3.7"
       }
     },
     "node_modules/p3-user/node_modules/uuid": {
@@ -12693,12 +12725,14 @@
     "node_modules/spdx-exceptions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A=="
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+      "dev": true
     },
     "node_modules/spdx-expression-parse": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
       "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
       "dependencies": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
@@ -12707,7 +12741,8 @@
     "node_modules/spdx-license-ids": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q=="
+      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
+      "dev": true
     },
     "node_modules/split": {
       "version": "1.0.1",
@@ -12913,6 +12948,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -12924,6 +12960,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -13424,7 +13461,8 @@
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
     },
     "node_modules/through": {
       "version": "2.3.8",
@@ -13969,6 +14007,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "morgan": "^1.9.1",
     "nconf": "^0.10.0",
     "node-xlsx": "^0.24.0",
+    "nodemailer": "^6.10.1",
     "npm": "^11.11.0",
     "p3-user": "git+https://github.com/PATRIC3/p3_user.git#c0fee2a0ac833fa78401266d705f8c5a6b80e4f3",
     "pino": "^6.2.1",


### PR DESCRIPTION
## Problem

The index workers (`bin/p3-index-worker`, `bin/p3-index-worker-once`) popped each queue message — renaming its file `new/ → cur/` — but never called the maildir `commit()`/`rollback()` the queue handed back (both were commented out). Since `queue.length()` counts only `new/`, a popped message stayed in `cur/` forever:

- **Errored jobs were never retried** (the reported bug).
- **Successful jobs also leaked** their queue file into `cur/` unbounded.

Jobs that hit a *transient* upstream failure — e.g. Solr/HAProxy returning an HTML error page instead of JSON (`Unexpected token '<', "<html><bod"... is not valid JSON`) — were marked `state: error` and abandoned, even though a retry would likely succeed.

## Fix

The workers now classify each failure and drive the queue transaction accordingly:

- **Transient** (any failure exiting the Solr POST path — network reset, non-2xx, HTML error page, or Solr-reported error): increment an `attempts` counter in the history file, roll the message back to `new/` for the next run. Capped at `email.indexMaxAttempts` (default **30**, ~one day of hourly cron runs) before becoming a permanent error.
- **Permanent** (ownership mismatch, malformed input JSON): `state: error`, committed, no retry.
- **Success**: `state: submitted`, committed — no more `cur/` leak.

Rollbacks are **deferred until the queue drains**, so a failing job retries on the *next* run rather than being re-popped in a tight loop within a single run (which would burn all 30 attempts at once).

When a run has any transient failures, the worker emails a summary to `email.indexAlertTo` (default `bvbrc-admin@lists.cels.anl.gov`).

## What's included

- **`lib/indexRetry.js`** (new) — shared classify + commit/rollback + history + deferred-rollback + summary-email logic, used by both workers so they stay in sync.
- **`lib/mailer.js`** (new) — config-driven `nodemailer` wrapper reading `config.get('email')`; header sanitization, subject cap. Adds `nodemailer@^6` as a direct dependency.
- **`bin/p3-requeue-errors`** (new) — recovers jobs already stranded in `cur/` from before this fix: moves them back to `new/`, resets `attempts`, and reports orphans whose queue file was lost. `--dry-run` / `--confirm`.
- **`config.js`** — new `email` block (`indexAlertTo`, `indexMaxAttempts` are tunable without a code change). Production SMTP credentials live in `p3api.conf`.

## Testing

Verified end-to-end against a local fake Solr (production untouched):
- HTML-502 response → `state: retrying`, `attempts` increments by exactly 1 per run, message returns to `new/`; reproduces the exact error string from the bug report.
- Ownership mismatch → `state: error`, no retry, committed.
- Success → `state: submitted`, `cur/` empty (leak fixed).
- `p3-requeue-errors` → error-state job moved `cur/ → new/` with `attempts: 0`; submitted jobs untouched; orphans reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
