### PR TITLE
Fix cleanup.par.pl reading no files under cron

### DIFF
--- a/cleanup.par.pl
+++ b/cleanup.par.pl
@@ -128,8 +128,11 @@ sub process_id {
 # Main execution
 my @ids;
 
-if (@ARGV || ! -t STDIN) {
-    # Read from file arguments or stdin (backward compatible)
+if (@ARGV || -p STDIN || -f STDIN) {
+    # Read from file arguments, a pipe, or a redirected file (backward compatible).
+    # Note: test for -p/-f rather than "! -t STDIN" — under cron stdin is /dev/null
+    # (a non-tty char device), and "! -t STDIN" would wrongly treat that as an
+    # empty id list and process nothing. -p/-f only match an actual pipe or file.
     @ids = <>;
     chomp @ids;
 } else {


### PR DESCRIPTION
## Problem

`cleanup.par.pl` run from cron always reports zero files and cleans nothing, even though it works correctly when run by hand.

The input-source check decides whether to read an id list from stdin or generate one by scanning `file_data/`:

```perl
if (@ARGV || ! -t STDIN) {
    @ids = <>;          # read ids from args/stdin
    ...
} else {
    @ids = get_ids_to_clean($file_data_dir, $keep_count);   # scan file_data/
}
```

`! -t STDIN` means "stdin is **not** a terminal." Under cron, stdin is attached to `/dev/null` (a non-tty char device), so `! -t STDIN` is true — the script reads an empty id list from `/dev/null` instead of scanning, and finds nothing. Run interactively (stdin = terminal) it takes the `else` branch and scans correctly.

## Fix

Test for an **actual** pipe (`-p`) or regular file (`-f`) rather than "not a tty":

```perl
if (@ARGV || -p STDIN || -f STDIN) {
```

- `foo | cleanup.par.pl` → pipe → reads stdin ✓
- `cleanup.par.pl < ids.txt` → file → reads stdin ✓
- cron (`/dev/null`, char device — neither `-p` nor `-f`) → scans `file_data/` ✓
- interactive tty → scans `file_data/` ✓

One-line change to the input-source selection; all existing invocation styles are preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
