### PR TITLE
cleanup.par.pl: read stdin only with explicit --stdin (fixes cron zero-files)

### DIFF
--- a/cleanup.par.pl
+++ b/cleanup.par.pl
@@ -14,6 +14,7 @@ my $keep_count = 1000;
 my $max_workers = 4;
 my $indexer_url = "http://localhost:3001/indexer";
 my $dry_run = 0;
+my $read_stdin = 0;
 
 GetOptions(
     "file-data-dir=s" => \$file_data_dir,
@@ -22,6 +23,7 @@ GetOptions(
     "workers=i"       => \$max_workers,
     "indexer-url=s"   => \$indexer_url,
     "dry-run"         => \$dry_run,
+    "stdin"           => \$read_stdin,
     "help"            => sub { usage(); exit 0; },
 ) or die "Error in command line arguments\n";
 
@@ -36,13 +38,21 @@ Options:
     --workers N           Number of parallel workers (default: 4)
     --indexer-url URL     Indexer endpoint URL (default: http://localhost:3001/indexer)
     --dry-run             List IDs that would be processed without making changes
+    --stdin               Read the id list from stdin (or pass ids as file args)
+                          instead of scanning file_data_dir. Required to consume
+                          a piped/redirected list; without it (and without file
+                          args) the script always scans file_data_dir. This keeps
+                          cron -- which hands the job an empty pipe -- on the scan
+                          path instead of reading zero ids from that empty pipe.
     --help                Show this help message
 
-This script:
+This script (default, no --stdin and no file args):
   1. Lists files in file_data_dir sorted by modification time (newest first)
   2. Skips the newest 'keep' files
   3. For remaining files, checks if state is "submitted" in history/
   4. If so, calls the indexer endpoint to trigger cleanup
+
+With --stdin or file arguments it processes exactly the ids given instead.
 EOF
 }
 
@@ -128,11 +138,13 @@ sub process_id {
 # Main execution
 my @ids;
 
-if (@ARGV || -p STDIN || -f STDIN) {
-    # Read from file arguments, a pipe, or a redirected file (backward compatible).
-    # Note: test for -p/-f rather than "! -t STDIN" — under cron stdin is /dev/null
-    # (a non-tty char device), and "! -t STDIN" would wrongly treat that as an
-    # empty id list and process nothing. -p/-f only match an actual pipe or file.
+if (@ARGV || $read_stdin) {
+    # Read ids from file arguments, or from stdin when --stdin is given.
+    # Reading stdin must be explicit: auto-detecting it by stdin type does not
+    # work under cron, which hands the job an EMPTY PIPE (not a tty, not
+    # /dev/null). Any "is stdin a pipe / not a tty" heuristic therefore matches
+    # cron's empty pipe and reads zero ids, cleaning nothing. So default to the
+    # internal scan and require --stdin (or file args) to consume a list.
     @ids = <>;
     chomp @ids;
 } else {


### PR DESCRIPTION
## Problem

`cleanup.par.pl` still found zero files under cron after the previous fix (#183).

That fix replaced `! -t STDIN` with `-p STDIN || -f STDIN`, on the assumption cron gives the job `/dev/null`. It doesn't: **Vixie cron connects a job's stdin to an empty pipe.** `-p STDIN` matches that pipe, so the script read an empty id list from it and cleaned nothing — same symptom as before.

No stdin-type heuristic can fix this: cron's empty pipe is indistinguishable from a real `foo | script` pipe. Both are pipes.

## Fix

Make stdin reading **explicit** instead of auto-detected:

- Add a `--stdin` flag.
- Read a piped/redirected id list only when `--stdin` (or file arguments) are given.
- Otherwise always scan `file_data/` internally.

Cron runs with neither `--stdin` nor file args, so it always takes the scan path.

```perl
if (@ARGV || $read_stdin) {
    @ids = <>;        # explicit: --stdin or file args
} else {
    @ids = get_ids_to_clean($file_data_dir, $keep_count);   # default: scan
}
```

## Behavior

- cron (`cleanup.par.pl` with no args) → scans `file_data/` ✓
- `cleanup.par.pl --stdin < ids.txt` → reads stdin ✓
- `foo | cleanup.par.pl --stdin` → reads stdin ✓
- `cleanup.par.pl id1 id2 …` → processes the given ids ✓

`--help` documents the new flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
