### PR TITLE
Indexing queue maintenance: requeue rewrite + purge-reloaded script

### DIFF
--- a/bin/p3-requeue-errors
+++ b/bin/p3-requeue-errors
@@ -1,28 +1,37 @@
 #!/usr/bin/env node
 
-// Recover index jobs stranded in 'error' state from before the retry fix.
+// Recover index jobs that failed and are sitting in a non-terminal-success state
+// (error / retrying) by re-enqueueing them for the worker.
 //
-// Background: popping a queue message renames its file new/ -> cur/. The old
-// worker never called commit()/rollback(), so errored (and even successful)
-// messages were left in cur/ forever and never reprocessed. This script finds
-// history entries in 'error' state, locates their queue message still sitting in
-// cur/, and renames it back to new/ so the next worker run picks it up. It also
-// resets the history entry (state 'queued', attempts 0, clears error fields).
+// Scans file_data/ rather than history/. A job is requeuable only if its payload
+// dir file_data/<id> still exists -- completion removes it, so file_data/ is
+// exactly the set of jobs that CAN be re-posted to Solr, and it is far smaller
+// than history/, which holds one (never-deleted) record per genome ever
+// submitted. For each file_data/<id> whose history state matches, the queue
+// message is reconstructed from the history record (which is literally the object
+// the indexer route pushed: {id, type, user, options, files}) and pushed fresh
+// onto the queue. History is then reset to state 'queued'.
+//
+// Re-pushing (rather than moving the old cur/ message back to new/) means we
+// don't depend on the pre-fix leaked cur/ files, and we also recover jobs that
+// hit the retry cap -- those were committed out of cur/ but still have file_data.
+// A leftover cur/ message for the same id is inert (tpop only reads new/), and a
+// re-post is harmless (overwrite=true).
 //
 // Usage:
-//   bin/p3-requeue-errors --dry-run     # list what would be requeued
-//   bin/p3-requeue-errors --confirm     # actually requeue
-//   bin/p3-requeue-errors --confirm --state error,retrying   # also retryings
+//   bin/p3-requeue-errors --dry-run                      # list what would requeue
+//   bin/p3-requeue-errors --confirm                      # actually requeue
+//   bin/p3-requeue-errors --confirm --state error,retrying
 
 const Config = require('../config')
 const opts = require('commander')
 const Path = require('path')
 const fs = require('fs-extra')
+const Queue = require('file-queue').Queue
 
 const queueDir = Config.get('queueDirectory')
 const historyDir = Path.join(queueDir, 'history')
-const newDir = Path.join(queueDir, 'new')
-const curDir = Path.join(queueDir, 'cur')
+const fileDataDir = Path.join(queueDir, 'file_data')
 
 if (require.main === module) {
   opts.option('-n, --dry-run', 'List what would be requeued without changing anything')
@@ -36,98 +45,132 @@ if (require.main === module) {
   }
 
   const states = opts.state.split(',').map((s) => s.trim()).filter(Boolean)
-  requeue(states, !!opts.confirm)
+  run(states, !!opts.confirm)
 }
 
-function requeue (states, confirm) {
-  // 1. Collect target ids from history.
-  const targetIds = new Map() // id -> history data
-  fs.readdirSync(historyDir).forEach((name) => {
+function run (states, confirm) {
+  let ids
+  try {
+    ids = fs.readdirSync(fileDataDir).filter((name) => {
+      try { return fs.statSync(Path.join(fileDataDir, name)).isDirectory() } catch (e) { return false }
+    })
+  } catch (e) {
+    console.error(`Cannot read file_data dir ${fileDataDir}: ${e.message}`)
+    process.exit(1)
+  }
+
+  console.log(`Scanning ${ids.length} file_data job(s) for state(s): ${states.join(', ')}`)
+
+  // Collect the requeuable candidates first (cheap, read-only), so a dry-run
+  // needs no queue and a real run opens the queue only if there's work.
+  const candidates = []
+  const skip = { noHistory: 0, wrongState: 0, noGenomeFile: 0 }
+
+  ids.forEach((id) => {
     let data
     try {
-      data = fs.readJsonSync(Path.join(historyDir, name))
+      data = fs.readJsonSync(Path.join(historyDir, id))
     } catch (e) {
-      return // corrupt / unreadable history file — skip
+      // No/unreadable history -> can't reconstruct the message reliably.
+      // Recover the history with bin/p3-rebuild-history, then re-run.
+      skip.noHistory++
+      return
     }
-    if (data && states.includes(data.state)) {
-      targetIds.set(data.id || name, data)
+
+    if (!data || !states.includes(data.state)) {
+      skip.wrongState++
+      return
     }
+
+    // The worker reads message.files.genome.path first (readJsonSync); if that
+    // file is gone the job can't run. Guard so we don't requeue a dead job.
+    const genomePath = data.files && data.files.genome && data.files.genome.path
+    if (!genomePath || !fs.existsSync(genomePath)) {
+      skip.noGenomeFile++
+      console.error(`  ${id}: genome payload missing, cannot requeue (state=${data.state})`)
+      return
+    }
+
+    candidates.push({ id, data })
   })
 
-  if (targetIds.size === 0) {
-    console.log(`No history entries in state(s): ${states.join(', ')}`)
+  console.log(`Requeuable: ${candidates.length}`)
+
+  if (candidates.length === 0 || !confirm) {
+    candidates.forEach(({ id, data }) => {
+      console.log(`[dry-run] would requeue ${id} (genome=${data.genomeId || '?'}, state=${data.state})`)
+    })
+    report(confirm, 0, candidates.length, skip)
     return
   }
-  console.log(`Found ${targetIds.size} history ent(y|ies) in state(s): ${states.join(', ')}`)
 
-  // 2. Map queue message files in cur/ to their job id (the file content is the
-  //    JSON message pushed by the indexer route, whose .id is the qid).
-  const curFiles = fs.existsSync(curDir) ? fs.readdirSync(curDir) : []
-  const idToCurFile = new Map()
-  curFiles.forEach((fname) => {
-    try {
-      const msg = fs.readJsonSync(Path.join(curDir, fname))
-      if (msg && msg.id) { idToCurFile.set(msg.id, fname) }
-    } catch (e) {
-      // not JSON / partial — ignore
+  // Open the queue (non-persistent: we push and exit, no watcher).
+  const queue = new Queue({ path: queueDir, persistent: false }, (err) => {
+    if (err) {
+      console.error(`Unable to open queue: ${err}`)
+      process.exit(1)
     }
+    requeueAll(queue, candidates, skip)
   })
+}
 
-  let moved = 0
-  const orphans = []
+function requeueAll (queue, candidates, skip) {
+  let requeued = 0
+  let i = 0
 
-  targetIds.forEach((data, id) => {
-    const fname = idToCurFile.get(id)
-    if (!fname) {
-      orphans.push(id)
-      return
+  const next = () => {
+    if (i >= candidates.length) {
+      report(true, requeued, candidates.length, skip)
+      process.exit(0)
+    }
+    const { id, data } = candidates[i++]
+
+    // Reconstruct exactly what the indexer route pushes.
+    const message = {
+      id: data.id || id,
+      type: data.type || 'genome',
+      user: data.user,
+      options: data.options || {},
+      files: data.files
     }
 
-    const from = Path.join(curDir, fname)
-    const to = Path.join(newDir, fname)
+    queue.push(message, (err) => {
+      if (err) {
+        console.error(`Failed to enqueue ${id}: ${err}`)
+        next()
+        return
+      }
+      // Reset history so the next worker run treats it as fresh.
+      try {
+        const hpath = Path.join(historyDir, id)
+        const hdata = fs.readJsonSync(hpath)
+        hdata.state = 'queued'
+        hdata.attempts = 0
+        delete hdata.error
+        delete hdata.lastError
+        delete hdata.lastAttemptTime
+        hdata.requeueTime = new Date()
+        fs.writeJsonSync(hpath, hdata)
+      } catch (e) {
+        console.error(`Enqueued ${id} but failed to reset history: ${e.message}`)
+      }
+      console.log(`Requeued ${id} (genome=${data.genomeId || '?'})`)
+      requeued++
+      next()
+    })
+  }
 
-    if (!confirm) {
-      console.log(`[dry-run] would requeue ${id} (genome=${data.genomeId || '?'}) : cur/${fname} -> new/${fname}`)
-      moved++
-      return
-    }
+  next()
+}
 
-    // cur/ and new/ are in the same maildir (same filesystem), so a rename is
-    // atomic and correct — this is exactly how file-queue's rollback moves them.
-    if (fs.existsSync(to)) {
-      console.error(`Target new/${fname} already exists; skipping ${id}`)
-      return
-    }
-    try {
-      fs.renameSync(from, to)
-    } catch (e) {
-      console.error(`Failed to move cur/${fname} -> new/: ${e.message}`)
-      return
-    }
-
-    // Reset history so the next run treats it as fresh.
-    try {
-      const hpath = Path.join(historyDir, id)
-      const hdata = fs.readJsonSync(hpath)
-      hdata.state = 'queued'
-      hdata.attempts = 0
-      delete hdata.error
-      delete hdata.lastError
-      delete hdata.lastAttemptTime
-      hdata.requeueTime = new Date()
-      fs.writeJsonSync(hpath, hdata)
-    } catch (e) {
-      console.error(`Requeued cur/${fname} but failed to reset history ${id}: ${e.message}`)
-    }
-
-    console.log(`Requeued ${id} (genome=${data.genomeId || '?'})`)
-    moved++
-  })
-
+function report (confirm, requeued, total, skip) {
   console.log('')
-  console.log(`${confirm ? 'Requeued' : 'Would requeue'}: ${moved}`)
-  if (orphans.length) {
-    console.log(`No queue message found in cur/ for ${orphans.length} error job(s) — their queue file was lost and they must be re-submitted manually:`)
-    orphans.forEach((id) => console.log(`  ${id}`))
+  console.log(`${confirm ? 'Requeued' : 'Would requeue'}: ${confirm ? requeued : total}`)
+  const skipped = skip.noHistory + skip.wrongState + skip.noGenomeFile
+  if (skipped) {
+    console.log(`Skipped: ${skipped}`)
+    console.log(`  state not in target set : ${skip.wrongState}`)
+    console.log(`  no/unreadable history   : ${skip.noHistory}  (run p3-rebuild-history)`)
+    console.log(`  genome payload missing  : ${skip.noGenomeFile}`)
   }
 }

--- a/purge-reloaded.par.pl
+++ b/purge-reloaded.par.pl
@@ -1,0 +1,198 @@
+#!/vol/patric3/cli/ubuntu-runtime/bin/perl
+use strict;
+use warnings;
+use Proc::ParallelLoop;
+use JSON;
+use File::Slurp;
+use File::Path qw(make_path);
+use File::Copy qw(move);
+use Getopt::Long;
+
+#
+# Specialty purge: relocate leftover payload/history for failed jobs that have
+# already been reloaded.
+#
+# Targets jobs that ALL of:
+#   * are owned by --owner            (default BVBRC@patricbrc.org)
+#   * were queued before --before     (default 2025-08-01, compared to queueTime)
+#
+# It does NOT delete. For each match it MOVES file_data/<id> to
+# <dest>/file_data/<id> and, unless --keep-history, history/<id> to
+# <dest>/history/<id>. Review/delete <dest> yourself once satisfied; restore by
+# moving back. Scans file_data/ -- the small set of jobs whose payload still
+# exists -- not history/, which holds one never-deleted record per genome ever
+# submitted.
+#
+# SAFE BY DEFAULT: prints what it would move and changes nothing unless --confirm
+# is given.
+#
+
+# Configuration
+my $file_data_dir = "file_data";
+my $history_dir   = "history";
+my $dest_dir;                          # required for --confirm
+my $owner         = 'BVBRC@patricbrc.org';
+my $before        = '2025-08-01';   # ISO date; queueTime is ISO-8601 UTC, sorts lexically
+my $max_workers   = 4;
+my $keep_history  = 0;
+my $confirm       = 0;
+
+GetOptions(
+    "file-data-dir=s" => \$file_data_dir,
+    "history-dir=s"   => \$history_dir,
+    "dest=s"          => \$dest_dir,
+    "owner=s"         => \$owner,
+    "before=s"        => \$before,
+    "workers=i"       => \$max_workers,
+    "keep-history"    => \$keep_history,
+    "confirm"         => \$confirm,
+    "help"            => sub { usage(); exit 0; },
+) or die "Error in command line arguments\n";
+
+sub usage {
+    print <<EOF;
+Usage: $0 --dest DIR [options]
+
+Relocates leftover file_data (and history) for failed jobs that have already been
+reloaded: those owned by a given user and queued before a cutoff date. Nothing is
+deleted -- matched jobs are MOVED under --dest so you can review and remove them
+yourself, or move them back to restore.
+
+Options:
+    --dest DIR            Destination to move matched jobs into. Required with
+                          --confirm. Creates DIR/file_data/<id> and
+                          DIR/history/<id>.
+    --file-data-dir DIR   Directory containing file data (default: file_data)
+    --history-dir DIR     Directory containing history JSON files (default: history)
+    --owner USER          Only purge jobs whose history 'user' matches
+                          (default: BVBRC\@patricbrc.org)
+    --before DATE         Only purge jobs queued before this ISO date, compared
+                          against the history 'queueTime' (default: 2025-08-01)
+    --workers N           Number of parallel workers (default: 4)
+    --keep-history        Move only file_data/<id>, leave the history record
+    --confirm             Actually move. Without this the script only reports
+                          what it would move (dry run).
+    --help                Show this help message
+
+Matching a job requires BOTH --owner and --before to hold. A job whose history
+is missing/unreadable, or has a different owner or a queueTime on/after the
+cutoff, is left untouched.
+EOF
+}
+
+# List candidate job ids: subdirectories of file_data/.
+sub get_job_ids {
+    my ($dir) = @_;
+    opendir(my $dh, $dir) or die "Cannot open directory '$dir': $!";
+    my @ids = grep { /^[a-z0-9]/i && -d "$dir/$_" } readdir($dh);
+    closedir($dh);
+    return @ids;
+}
+
+# Decide whether a single id matches the purge criteria. Returns the matching
+# history data hashref, or undef.
+sub job_matches {
+    my ($id) = @_;
+
+    my $json_file = "$history_dir/$id";
+    return undef unless -f $json_file;
+
+    my $text = eval { read_file($json_file) };
+    return undef unless defined $text && length $text;
+
+    my $data = eval { decode_json($text) };
+    if ($@ || !$data) {
+        warn "Failed to parse history for $id: $@" if $@;
+        return undef;
+    }
+
+    my $job_owner = $data->{user};
+    return undef unless defined $job_owner && $job_owner eq $owner;
+
+    my $queued = $data->{queueTime};
+    return undef unless defined $queued;
+    # queueTime is ISO-8601 UTC (e.g. 2025-07-09T13:03:32.894Z); a lexical
+    # compare against the YYYY-MM-DD cutoff is a correct chronological test.
+    return undef unless $queued lt $before;
+
+    return $data;
+}
+
+# Process (report or move) one id.
+sub process_id {
+    my ($id) = @_;
+
+    my $data = job_matches($id);
+    return unless $data;
+
+    my $genome  = $data->{genomeId} // '?';
+    my $queued  = $data->{queueTime} // '?';
+    my $fd_src  = "$file_data_dir/$id";
+    my $h_src   = "$history_dir/$id";
+    my $fd_dst  = "$dest_dir/file_data/$id";
+    my $h_dst   = "$dest_dir/history/$id";
+
+    if (!$confirm) {
+        print "[dry-run] would move $id (genome=$genome queued=$queued) -> $dest_dir/\n";
+        return;
+    }
+
+    # Move the payload dir first. If it fails, leave everything in place so the
+    # job stays intact and recoverable.
+    make_path("$dest_dir/file_data");
+    if (-e $fd_dst) {
+        warn "Destination $fd_dst already exists; skipping $id\n";
+        return;
+    }
+    unless (move($fd_src, $fd_dst)) {
+        warn "Failed to move $fd_src -> $fd_dst: $!\n";
+        return;
+    }
+
+    unless ($keep_history) {
+        make_path("$dest_dir/history");
+        if (-e $h_dst) {
+            warn "Moved file_data but $h_dst already exists; left history $h_src in place for $id\n";
+        } elsif (-f $h_src && !move($h_src, $h_dst)) {
+            warn "Moved file_data but failed to move history $h_src -> $h_dst: $!\n";
+        }
+    }
+
+    print "moved $id (genome=$genome queued=$queued)\n";
+}
+
+# Main execution
+if ($confirm && !defined $dest_dir) {
+    die "--dest DIR is required with --confirm (nothing is deleted; matches are moved there)\n";
+}
+if (!defined $dest_dir) {
+    $dest_dir = '<dest>';   # placeholder for dry-run output only
+}
+
+my @ids = get_job_ids($file_data_dir);
+print STDERR "Scanning ", scalar(@ids), " file_data job(s): owner=$owner before=$before",
+             ($confirm ? " -> $dest_dir" : " (dry run)"), "\n";
+
+if (@ids == 0) {
+    print STDERR "No jobs to process.\n";
+    exit 0;
+}
+
+# Chunk the ids
+my $chunk_size = 1000;
+my @chunks;
+while (@ids) {
+    my @s = splice(@ids, 0, $chunk_size);
+    push(@chunks, [@s]);
+}
+
+pareach(
+    \@chunks,
+    sub {
+        my $chunk = shift;
+        for my $id (@$chunk) {
+            process_id($id);
+        }
+    },
+    { Max_Workers => $max_workers }
+);


### PR DESCRIPTION
Two indexing-queue maintenance changes.

## 1. `p3-requeue-errors`: scan file_data and re-push (not scan history)

The script scanned `history/` to find jobs to requeue, but `history/` holds one never-deleted record per genome ever submitted (~500k on production) while the requeuable set is only jobs whose payload dir `file_data/<id>` still exists — completion removes it. Now it scans `file_data/`, which is exactly the recoverable set and far smaller.

Inverting the scan also fixes two latent bugs:
- **No more `cur/` dependency.** The old code moved the leaked `cur/` maildir message back to `new/`, but `cur/` filenames don't encode the job id, so it had to read all of `cur/` (also huge). Now the queue message is reconstructed from the history record — which is the exact object the indexer route pushed, `{id, type, user, options, files}` — and pushed fresh via the queue API.
- **Cap-error jobs are now recoverable.** Jobs that hit the retry cap were committed out of `cur/`, so the old code wrongly reported them as unrecoverable orphans. Their `file_data` is intact, so re-pushing recovers them.

A leftover `cur/` message is inert (`tpop` reads only `new/`) and a re-post is harmless (`overwrite=true`). Jobs with no/unreadable history (points at `p3-rebuild-history`) or a missing genome payload are skipped, with a per-reason breakdown.

## 2. `purge-reloaded.par.pl`: relocate reloaded failed jobs

A large number of failed indexing jobs owned by `BVBRC@patricbrc.org` and queued before August 2025 have already been reloaded, leaving their `file_data` payloads and never-deleted history records behind.

This script scans `file_data/` and matches jobs whose history `user` equals `--owner` (default `BVBRC@patricbrc.org`) **and** whose `queueTime` is before `--before` (default `2025-08-01`; `queueTime` is ISO-8601 UTC so a lexical compare is chronological).

It does **not** delete — matched jobs are **moved** to `--dest/file_data/<id>` and `--dest/history/<id>` for review, and can be restored by moving back. `--dest` is required with `--confirm`; without `--confirm` it is a dry run. Payload is moved first and history left in place on any failure, so a job is never left partial. Follows `cleanup.par.pl`'s Perl / Getopt::Long / Proc::ParallelLoop style.

## Testing

Both verified end-to-end against temp queue dirs:
- **requeue**: error w/ payload → requeued; error at retry cap (no `cur/` message) → requeued; retrying → requeued only with `--state error,retrying`; indexed → skipped; missing genome payload → skipped; no history → skipped (flagged for rebuild). History reset to `queued`/`attempts:0`; pushed message correctly reconstructed.
- **purge-reloaded**: matches only correct owner + pre-cutoff `queueTime`; `--confirm` requires `--dest`; matched jobs moved (not deleted) with payload intact; wrong-owner / post-cutoff / no-history left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
