### PR TITLE
p3-requeue-errors: add --queue-dir and show genome id for error jobs

### DIFF
--- a/bin/p3-requeue-errors
+++ b/bin/p3-requeue-errors
@@ -29,15 +29,26 @@ const Path = require('path')
 const fs = require('fs-extra')
 const Queue = require('file-queue').Queue
 
-const queueDir = Config.get('queueDirectory')
-const historyDir = Path.join(queueDir, 'history')
-const fileDataDir = Path.join(queueDir, 'file_data')
+// Queue location. Defaults to config, but --queue-dir overrides it so the script
+// can be run against a queue dir directly (e.g. from within it) without needing
+// p3api.conf on the cwd -- otherwise require('../config') falls back to the
+// built-in default './index-queue-dir' relative to wherever you invoked it.
+let queueDir = Config.get('queueDirectory')
+let historyDir = Path.join(queueDir, 'history')
+let fileDataDir = Path.join(queueDir, 'file_data')
 
 if (require.main === module) {
   opts.option('-n, --dry-run', 'List what would be requeued without changing anything')
     .option('-c, --confirm', 'Perform the requeue')
     .option('-s, --state <values>', 'Comma-separated history states to requeue (default: error)', 'error')
+    .option('-q, --queue-dir <dir>', 'Queue directory (overrides config queueDirectory)')
     .parse(process.argv)
+
+  if (opts.queueDir) {
+    queueDir = opts.queueDir
+    historyDir = Path.join(queueDir, 'history')
+    fileDataDir = Path.join(queueDir, 'file_data')
+  }
 
   if (!opts.dryRun && !opts.confirm) {
     console.error('Specify --dry-run to preview, or --confirm to requeue.')

--- a/bin/p3-requeue-errors
+++ b/bin/p3-requeue-errors
@@ -59,6 +59,20 @@ if (require.main === module) {
   run(states, !!opts.confirm)
 }
 
+// Read the genome_id from a genome payload file (first record). Used to display
+// the genome for error/retrying jobs, whose history record has no genomeId.
+function genomeIdFromPayload (genomePath) {
+  try {
+    const arr = fs.readJsonSync(genomePath)
+    if (Array.isArray(arr) && arr[0] && arr[0].genome_id) {
+      return arr[0].genome_id
+    }
+  } catch (e) {
+    // fall through
+  }
+  return undefined
+}
+
 function run (states, confirm) {
   let ids
   try {
@@ -100,6 +114,13 @@ function run (states, confirm) {
       skip.noGenomeFile++
       console.error(`  ${id}: genome payload missing, cannot requeue (state=${data.state})`)
       return
+    }
+
+    // History only records genomeId once a job reaches 'submitted'; error/retrying
+    // records lack it. Recover it from the payload (same file the worker reads) so
+    // the output is vettable.
+    if (!data.genomeId) {
+      data.genomeId = genomeIdFromPayload(genomePath)
     }
 
     candidates.push({ id, data })
@@ -161,6 +182,8 @@ function requeueAll (queue, candidates, skip) {
         delete hdata.lastError
         delete hdata.lastAttemptTime
         hdata.requeueTime = new Date()
+        // Backfill genomeId recovered from the payload if history lacked it.
+        if (!hdata.genomeId && data.genomeId) { hdata.genomeId = data.genomeId }
         fs.writeJsonSync(hpath, hdata)
       } catch (e) {
         console.error(`Enqueued ${id} but failed to reset history: ${e.message}`)


### PR DESCRIPTION
Two usability fixes to `p3-requeue-errors`, both surfaced while running it on production.

## 1. `--queue-dir` to override the config location

Run from within the queue directory, `require('../config')` found no `p3api.conf` on the cwd and fell back to the built-in default `./index-queue-dir`, so the script looked for `index-queue-dir/file_data` relative to the invocation dir and failed:

```
Cannot read file_data dir index-queue-dir/file_data: ENOENT ...
```

Added `--queue-dir` / `-q` to point the script at a queue directory explicitly, independent of config and cwd:

```
p3-requeue-errors -n --queue-dir /disks1/p3/var/indexing_queue.solr9
```

## 2. Show the genome id for error jobs

History records only carry `genomeId` once a job reaches `submitted` — `error` and `retrying` records never had it, so the output showed `genome=?`, making it hard to vet what's being requeued:

```
[dry-run] would requeue ffbd0f7b-... (genome=?, state=error)
```

Now the `genome_id` is recovered from the payload the worker itself reads (`file_data/<id>/genome.json`, first record), at the point we already validate that file exists — so no extra I/O for non-matching jobs. On requeue the recovered id is also backfilled into the history record.

```
[dry-run] would requeue ffbd0f7b-... (genome=562.99999, state=error)
```

## Testing

Verified against temp queue dirs: `--queue-dir`/`-q` resolves the queue from an unrelated cwd (dry-run and confirm); genome id displayed from payload for a history record lacking `genomeId`, and backfilled into history after confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
